### PR TITLE
Sync IsTeacher from config to DB on every sign-in

### DIFF
--- a/src/handlers/auth.go
+++ b/src/handlers/auth.go
@@ -179,6 +179,11 @@ func SigninHandler(w http.ResponseWriter, r *http.Request) {
 
 	// Teacher status is determined by config, not stored value
 	isTeacher := AppConfig.IsTeacher(user.ID)
+	if user.IsTeacher != isTeacher {
+		if err := DB.UpdateIsTeacher(user.ID, isTeacher); err != nil {
+			log.Printf("action=signin user=%s error syncing teacher status: %v", user.ID, err)
+		}
+	}
 	tokenString, err := JwtAuth.GenerateToken(user.Username, user.ID, true, isTeacher)
 	if err != nil {
 		renderAuthPageWithError(w, "Error generating token")

--- a/src/storage/user.go
+++ b/src/storage/user.go
@@ -169,6 +169,18 @@ func (d *DB) UpdatePassword(userID string, passwordHash []byte) error {
 	})
 }
 
+func (d *DB) UpdateIsTeacher(userID UserID, isTeacher bool) error {
+	return d.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(d.bucketName)
+		user, err := getValue[UserData](b, userID)
+		if err != nil {
+			return err
+		}
+		user.IsTeacher = isTeacher
+		return setValue(b, userID, *user)
+	})
+}
+
 func (d *DB) UpdateUsername(userID, username string) error {
 	return d.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(d.bucketName)


### PR DESCRIPTION
The DB IsTeacher field was only set at sign-up, so adding a user to teacher_ids in config would only take effect after JWT expiry (24h). Now sign-in updates the DB value when it differs from config, keeping them consistent.