### PR TITLE
Hide past lessons by default with show/hide toggle

### DIFF
--- a/src/handlers/common.go
+++ b/src/handlers/common.go
@@ -26,6 +26,7 @@ type User struct {
 	TaskScores       map[storage.TaskID]string
 	Journals         map[storage.TaskID][]storage.TaskRecord
 	Lessons          []*storage.Lesson
+	ShowPastLessons  bool
 	Now              time.Time
 	DefaultDateTime  time.Time
 	TZName           string

--- a/src/handlers/user.go
+++ b/src/handlers/user.go
@@ -67,6 +67,9 @@ func UserInfoHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	showPast := r.URL.Query().Get("showPast") == "true"
+	now := time.Now()
+
 	user = User{
 		Username:         dbUser.Username,
 		ID:               dbUser.ID,
@@ -79,7 +82,8 @@ func UserInfoHandler(w http.ResponseWriter, r *http.Request) {
 		TaskScores:       taskScores,
 		Journals:         journals,
 		Lessons:          []*storage.Lesson{},
-		Now:              time.Now(),
+		ShowPastLessons:  showPast,
+		Now:              now,
 		DefaultDateTime:  getTomorrowNoon(),
 		TZName:           PrimaryTZName,
 	}
@@ -89,7 +93,15 @@ func UserInfoHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Printf("Error loading lessons: %v", err)
 	} else {
-		user.Lessons = lessons
+		if showPast {
+			user.Lessons = lessons
+		} else {
+			for _, l := range lessons {
+				if !l.DateTime.Before(now) {
+					user.Lessons = append(user.Lessons, l)
+				}
+			}
+		}
 	}
 
 	renderPage(w, "templates/user.html", user)

--- a/templates/user.html
+++ b/templates/user.html
@@ -26,7 +26,14 @@
 <section class="mb-8">
   <div class="text-xs text-gray-500 mb-2 flex items-center justify-between">
     <span>// lessons</span>
-    <span class="text-gray-600">[reviewed/registered]</span>
+    <span class="flex items-center space-x-2">
+      <span class="text-gray-600">[reviewed/registered]</span>
+      {{ if .ShowPastLessons }}
+      <a class="text-blue-400 hover:text-blue-300" href="?">[ hide past]</a>
+    {{ else }}
+      <a class="text-blue-400 hover:text-blue-300" href="?showPast=true">[show past]</a>
+      {{ end }}
+    </span>
   </div>
   {{template "lesson_list.html" .}}
 </section>


### PR DESCRIPTION
## Summary
- Past lessons are hidden by default on the user profile page
- A `[show past]` / `[hide past]` ghost link in the `// lessons` section header toggles visibility via `?showPast=true` query param