### PR TITLE
Add GitHub repository link to page header

### DIFF
--- a/templates/partials/layout.html
+++ b/templates/partials/layout.html
@@ -23,6 +23,7 @@
         <div hx-trigger="load" hx-get="/parts/user-line">
         </div>
         <span>v{{appVersion}} · up {{uptime}}</span>
+        <a class="hover:text-gray-400" href="https://github.com/ryukzak/slap">[github]</a>
       </div>
     </header>
     <main class="container mx-auto px-4 pt-2 pb-4">


### PR DESCRIPTION
## Summary
- Added a `[github]` ghost link in the right side of the page header pointing to the repository