### PR TITLE
Add task-mix and student-mix sort modes for lesson records

### DIFF
--- a/src/handlers/lesson.go
+++ b/src/handlers/lesson.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/ryukzak/slap/src/analytics"
 	"github.com/ryukzak/slap/src/storage"
+	"github.com/ryukzak/slap/src/util"
 )
 
 func CreateLessonHandler(w http.ResponseWriter, r *http.Request) {
@@ -71,9 +72,10 @@ type lessonRecordsData struct {
 	TotalRecords     int
 	SessionIsTeacher bool
 	SessionUserID    string
+	SortMode         SortMode
 }
 
-func buildLessonRecords(lesson *storage.Lesson, showRevoked bool) ([]TaskRecordWithInfo, int, error) {
+func buildLessonRecords(lesson *storage.Lesson, showRevoked bool, sortMode SortMode) ([]TaskRecordWithInfo, int, error) {
 	taskRecords, err := DB.ListLessonTaskRecords(lesson)
 	if err != nil {
 		return nil, 0, err
@@ -161,6 +163,14 @@ func buildLessonRecords(lesson *storage.Lesson, showRevoked bool) ([]TaskRecordW
 			visible = append(visible, r)
 		}
 	}
+
+	switch sortMode {
+	case SortByTaskMix:
+		visible = util.InterleaveByKey(visible, func(r TaskRecordWithInfo) string { return string(r.TaskID) })
+	case SortByStudentMix:
+		visible = util.InterleaveByKey(visible, func(r TaskRecordWithInfo) string { return r.StudentID })
+	}
+
 	return visible, totalRecords, nil
 }
 
@@ -173,6 +183,7 @@ func LessonDetailHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	lessonID := vars["lessonID"]
 	showRevoked := r.URL.Query().Get("showRevoked") == "true"
+	sortMode := ParseSortMode(r.URL.Query().Get("sort"))
 
 	lesson, err := DB.GetLesson(storage.LessonID(lessonID))
 	if err != nil {
@@ -181,7 +192,7 @@ func LessonDetailHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	visibleTaskRecords, totalRecords, err := buildLessonRecords(lesson, showRevoked)
+	visibleTaskRecords, totalRecords, err := buildLessonRecords(lesson, showRevoked, sortMode)
 	if err != nil {
 		log.Printf("Error fetching task records for lesson %s: %v", lesson.ID, err)
 		http.Error(w, "Error fetching task records", http.StatusInternalServerError)
@@ -208,6 +219,7 @@ func LessonDetailHandler(w http.ResponseWriter, r *http.Request) {
 		TotalRecords     int
 		DefaultDateTime  time.Time
 		TZName           string
+		SortMode         SortMode
 	}{
 		Lesson:           lesson,
 		TeacherID:        lesson.TeacherID,
@@ -218,6 +230,7 @@ func LessonDetailHandler(w http.ResponseWriter, r *http.Request) {
 		TotalRecords:     totalRecords,
 		DefaultDateTime:  time.Now().In(PrimaryLoc).Add(15 * time.Minute),
 		TZName:           PrimaryTZName,
+		SortMode:         sortMode,
 	})
 }
 
@@ -229,6 +242,7 @@ func LessonTaskRecordsPartialHandler(w http.ResponseWriter, r *http.Request) {
 
 	lessonID := mux.Vars(r)["lessonID"]
 	showRevoked := r.URL.Query().Get("showRevoked") == "true"
+	sortMode := ParseSortMode(r.URL.Query().Get("sort"))
 
 	lesson, err := DB.GetLesson(storage.LessonID(lessonID))
 	if err != nil {
@@ -237,7 +251,7 @@ func LessonTaskRecordsPartialHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	visibleTaskRecords, totalRecords, err := buildLessonRecords(lesson, showRevoked)
+	visibleTaskRecords, totalRecords, err := buildLessonRecords(lesson, showRevoked, sortMode)
 	if err != nil {
 		log.Printf("Error fetching task records for lesson %s: %v", lesson.ID, err)
 		http.Error(w, "Error fetching task records", http.StatusInternalServerError)
@@ -259,6 +273,8 @@ func LessonTaskRecordsPartialHandler(w http.ResponseWriter, r *http.Request) {
 		ShowRevoked:      showRevoked,
 		TotalRecords:     totalRecords,
 		SessionIsTeacher: user.IsTeacher,
+		SessionUserID:    user.ID,
+		SortMode:         sortMode,
 	}
 
 	t, err := BaseTemplates.Clone()

--- a/src/handlers/sort.go
+++ b/src/handlers/sort.go
@@ -1,0 +1,20 @@
+package handlers
+
+// SortMode controls the order of task records on the lesson page.
+type SortMode string
+
+const (
+	SortByDate       SortMode = "date"
+	SortByTaskMix    SortMode = "task-mix"
+	SortByStudentMix SortMode = "student-mix"
+)
+
+// ParseSortMode returns a valid SortMode from a string, defaulting to date.
+func ParseSortMode(s string) SortMode {
+	switch SortMode(s) {
+	case SortByTaskMix, SortByStudentMix:
+		return SortMode(s)
+	default:
+		return SortByDate
+	}
+}

--- a/src/handlers/sort_test.go
+++ b/src/handlers/sort_test.go
@@ -1,0 +1,145 @@
+package handlers
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ryukzak/slap/src/storage"
+	"github.com/ryukzak/slap/src/util"
+)
+
+func TestParseSortMode_Valid(t *testing.T) {
+	tests := []struct {
+		input string
+		want  SortMode
+	}{
+		{"date", SortByDate},
+		{"task-mix", SortByTaskMix},
+		{"student-mix", SortByStudentMix},
+	}
+	for _, tt := range tests {
+		got := ParseSortMode(tt.input)
+		if got != tt.want {
+			t.Errorf("ParseSortMode(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestParseSortMode_Unknown(t *testing.T) {
+	for _, input := range []string{"", "unknown", "TASK-MIX", "Date"} {
+		got := ParseSortMode(input)
+		if got != SortByDate {
+			t.Errorf("ParseSortMode(%q) = %q, want %q", input, got, SortByDate)
+		}
+	}
+}
+
+// reg is a shorthand for a registration: student + task, ordered by creation time.
+type reg struct{ student, task string }
+
+func (r reg) String() string { return r.student + ":" + r.task }
+
+func makeRecords(regs []reg) []TaskRecordWithInfo {
+	out := make([]TaskRecordWithInfo, len(regs))
+	for i, r := range regs {
+		out[i] = TaskRecordWithInfo{
+			TaskRecord: storage.TaskRecord{
+				TaskID:    storage.TaskID(r.task),
+				StudentID: storage.UserID(r.student),
+				CreatedAt: time.Date(2025, 1, 1, 0, i, 0, 0, time.UTC),
+			},
+		}
+	}
+	return out
+}
+
+func applySortMode(records []TaskRecordWithInfo, mode SortMode) []TaskRecordWithInfo {
+	switch mode {
+	case SortByTaskMix:
+		return util.InterleaveByKey(records, func(r TaskRecordWithInfo) string { return string(r.TaskID) })
+	case SortByStudentMix:
+		return util.InterleaveByKey(records, func(r TaskRecordWithInfo) string { return r.StudentID })
+	default:
+		return records
+	}
+}
+
+func formatSequence(records []TaskRecordWithInfo) string {
+	parts := make([]string, len(records))
+	for i, r := range records {
+		parts[i] = fmt.Sprintf("%s:%s", r.StudentID, r.TaskID)
+	}
+	return strings.Join(parts, " ")
+}
+
+func TestSortModes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    []reg
+		mode     SortMode
+		expected string // "student:task student:task ..."
+	}{
+		{
+			name:     "date: keeps original order",
+			input:    []reg{{"Alice", "T1"}, {"Bob", "T1"}, {"Alice", "T2"}, {"Bob", "T2"}},
+			mode:     SortByDate,
+			expected: "Alice:T1 Bob:T1 Alice:T2 Bob:T2",
+		},
+		{
+			name:     "task-mix: alternates between tasks",
+			input:    []reg{{"Alice", "T1"}, {"Bob", "T1"}, {"Alice", "T2"}, {"Bob", "T2"}},
+			mode:     SortByTaskMix,
+			expected: "Alice:T1 Alice:T2 Bob:T1 Bob:T2",
+		},
+		{
+			name:     "student-mix: alternates between students",
+			input:    []reg{{"Alice", "T1"}, {"Bob", "T1"}, {"Alice", "T2"}, {"Bob", "T2"}},
+			mode:     SortByStudentMix,
+			expected: "Alice:T1 Bob:T1 Alice:T2 Bob:T2",
+		},
+		{
+			name:     "task-mix: three tasks, unequal sizes",
+			input:    []reg{{"Alice", "T1"}, {"Bob", "T1"}, {"Carol", "T1"}, {"Dave", "T2"}, {"Eve", "T3"}},
+			mode:     SortByTaskMix,
+			expected: "Alice:T1 Dave:T2 Eve:T3 Bob:T1 Carol:T1",
+		},
+		{
+			name:     "student-mix: three students, unequal sizes",
+			input:    []reg{{"Alice", "T1"}, {"Alice", "T2"}, {"Alice", "T3"}, {"Bob", "T4"}, {"Carol", "T5"}},
+			mode:     SortByStudentMix,
+			expected: "Alice:T1 Bob:T4 Carol:T5 Alice:T2 Alice:T3",
+		},
+		{
+			name:     "task-mix: single task unchanged",
+			input:    []reg{{"Alice", "T1"}, {"Bob", "T1"}, {"Carol", "T1"}},
+			mode:     SortByTaskMix,
+			expected: "Alice:T1 Bob:T1 Carol:T1",
+		},
+		{
+			name:     "student-mix: single student unchanged",
+			input:    []reg{{"Alice", "T1"}, {"Alice", "T2"}, {"Alice", "T3"}},
+			mode:     SortByStudentMix,
+			expected: "Alice:T1 Alice:T2 Alice:T3",
+		},
+		{
+			name:     "empty input",
+			input:    []reg{},
+			mode:     SortByTaskMix,
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			records := makeRecords(tt.input)
+			result := applySortMode(records, tt.mode)
+			got := formatSequence(result)
+			if got != tt.expected {
+				t.Errorf("\n  input:    %v\n  mode:     %s\n  expected: %s\n  got:      %s",
+					tt.input, tt.mode, tt.expected, got)
+			}
+		})
+	}
+}

--- a/src/util/interleave.go
+++ b/src/util/interleave.go
@@ -1,0 +1,32 @@
+package util
+
+// InterleaveByKey performs round-robin interleaving of items grouped by keyFn.
+// Groups are ordered by first appearance. Within each group, order is preserved.
+func InterleaveByKey[T any](items []T, keyFn func(T) string) []T {
+	if len(items) == 0 {
+		return items
+	}
+
+	groups := map[string][]T{}
+	var order []string
+	for _, item := range items {
+		k := keyFn(item)
+		if _, seen := groups[k]; !seen {
+			order = append(order, k)
+		}
+		groups[k] = append(groups[k], item)
+	}
+
+	result := make([]T, 0, len(items))
+	idx := make(map[string]int, len(order))
+	for len(result) < len(items) {
+		for _, k := range order {
+			i := idx[k]
+			if i < len(groups[k]) {
+				result = append(result, groups[k][i])
+				idx[k] = i + 1
+			}
+		}
+	}
+	return result
+}

--- a/src/util/interleave_test.go
+++ b/src/util/interleave_test.go
@@ -1,0 +1,82 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+type item struct {
+	group string
+	id    string
+}
+
+func byGroup(i item) string { return i.group }
+
+func keys(items []item) string {
+	parts := make([]string, len(items))
+	for i, v := range items {
+		parts[i] = v.group
+	}
+	return strings.Join(parts, ",")
+}
+
+func TestInterleaveByKey_Empty(t *testing.T) {
+	result := InterleaveByKey([]item{}, byGroup)
+	if len(result) != 0 {
+		t.Fatalf("expected empty, got %d", len(result))
+	}
+}
+
+func TestInterleaveByKey_Nil(t *testing.T) {
+	result := InterleaveByKey(nil, byGroup)
+	if result != nil {
+		t.Fatalf("expected nil, got %v", result)
+	}
+}
+
+func TestInterleaveByKey_SingleGroup(t *testing.T) {
+	input := []item{{"a", "1"}, {"a", "2"}, {"a", "3"}}
+	result := InterleaveByKey(input, byGroup)
+	got := keys(result)
+	if got != "a,a,a" {
+		t.Fatalf("expected a,a,a, got %s", got)
+	}
+	if result[0].id != "1" || result[1].id != "2" || result[2].id != "3" {
+		t.Fatalf("within-group order not preserved")
+	}
+}
+
+func TestInterleaveByKey_TwoEqualGroups(t *testing.T) {
+	input := []item{{"a", "1"}, {"a", "2"}, {"b", "3"}, {"b", "4"}}
+	result := InterleaveByKey(input, byGroup)
+	got := keys(result)
+	if got != "a,b,a,b" {
+		t.Fatalf("expected a,b,a,b, got %s", got)
+	}
+}
+
+func TestInterleaveByKey_UnequalGroups(t *testing.T) {
+	input := []item{{"a", "1"}, {"a", "2"}, {"a", "3"}, {"b", "4"}}
+	result := InterleaveByKey(input, byGroup)
+	got := keys(result)
+	if got != "a,b,a,a" {
+		t.Fatalf("expected a,b,a,a, got %s", got)
+	}
+}
+
+func TestInterleaveByKey_ThreeGroups(t *testing.T) {
+	input := []item{{"a", "1"}, {"a", "2"}, {"b", "3"}, {"b", "4"}, {"c", "5"}}
+	result := InterleaveByKey(input, byGroup)
+	got := keys(result)
+	if got != "a,b,c,a,b" {
+		t.Fatalf("expected a,b,c,a,b, got %s", got)
+	}
+}
+
+func TestInterleaveByKey_WithinGroupOrderPreserved(t *testing.T) {
+	input := []item{{"a", "1"}, {"a", "2"}, {"b", "3"}, {"b", "4"}}
+	result := InterleaveByKey(input, byGroup)
+	if result[0].id != "1" || result[1].id != "3" || result[2].id != "2" || result[3].id != "4" {
+		t.Fatalf("expected interleaved with preserved group order, got %v", result)
+	}
+}

--- a/templates/lesson.html
+++ b/templates/lesson.html
@@ -142,7 +142,7 @@
       </form>
       {{ end }}
     </span>
-    <span>
+    <span class="space-x-2">
       <button class="text-blue-400 hover:text-blue-300 text-xs"
               type="button"
               data-action="open-all"
@@ -150,14 +150,34 @@
         [open queued]
       </button>
       {{ if .ShowRevoked }}
-      <a class="text-blue-400 hover:text-blue-300" href="?">[hide history]</a>
+      <a class="text-blue-400 hover:text-blue-300" href="?sort={{.SortMode}}">[hide history]</a>
     {{ else }}
-      <a class="text-blue-400 hover:text-blue-300" href="?showRevoked=true">[show history]</a>
+      <a class="text-blue-400 hover:text-blue-300"
+         href="?showRevoked=true&sort={{.SortMode}}">[show history]</a>
+      {{ end }}
+      <span class="text-gray-600">|</span>
+      {{ if eq (printf "%s" .SortMode) "date" }}
+      date
+    {{ else }}
+      <a class="text-blue-400 hover:text-blue-300"
+         href="?showRevoked={{.ShowRevoked}}&sort=date">date</a>
+      {{ end }}
+      {{ if eq (printf "%s" .SortMode) "task-mix" }}
+      task-mix
+    {{ else }}
+      <a class="text-blue-400 hover:text-blue-300"
+         href="?showRevoked={{.ShowRevoked}}&sort=task-mix">task-mix</a>
+      {{ end }}
+      {{ if eq (printf "%s" .SortMode) "student-mix" }}
+      student-mix
+    {{ else }}
+      <a class="text-blue-400 hover:text-blue-300"
+         href="?showRevoked={{.ShowRevoked}}&sort=student-mix">student-mix</a>
       {{ end }}
     </span>
   </div>
   <div id="lesson-task-records"
-       hx-get="/lesson/{{.Lesson.ID}}/records?showRevoked={{.ShowRevoked}}"
+       hx-get="/lesson/{{.Lesson.ID}}/records?showRevoked={{.ShowRevoked}}&sort={{.SortMode}}"
        hx-trigger="lessonRecordsRefresh"
        hx-swap="innerHTML">
     {{template "lesson_task_records.html" .}}

--- a/templates/partials/lesson_task_records.html
+++ b/templates/partials/lesson_task_records.html
@@ -117,7 +117,7 @@
   No visible task records. {{ .TotalRecords }} revoked
 {{ if eq .TotalRecords 1 }}record{{ else }}records{{ end }} hidden.
   <a class="text-blue-400 hover:text-blue-300 ml-1"
-     href="?showRevoked=true">[show history]</a>
+     href="?showRevoked=true&sort={{.SortMode}}">[show history]</a>
 {{ else }}
   No registered task records for this lesson yet.
   {{ end }}


### PR DESCRIPTION
## Summary
- Add three sorting options for lesson task records: by date (default), task-mix (round-robin by task), and student-mix (round-robin by student)
- Implement generic `InterleaveByKey` utility for round-robin interleaving
- Add sort mode toggle links to lesson page toolbar

Closes #21

## Test plan
- [x] Unit tests for `ParseSortMode` (valid/invalid inputs)
- [x] Unit tests for sort mode behavior with various record distributions
- [x] Unit tests for `InterleaveByKey` (empty, single group, equal/unequal groups, order preservation)