### PR TITLE
Fix lesson list timezone and link lessons in activity

### DIFF
--- a/src/handlers/lesson.go
+++ b/src/handlers/lesson.go
@@ -290,8 +290,8 @@ func RenderLessonListHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	now := time.Now()
-	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	now := time.Now().In(PrimaryLoc)
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, PrimaryLoc)
 
 	availableLessons := []*storage.Lesson{}
 	for _, lesson := range lessons {

--- a/templates/users.html
+++ b/templates/users.html
@@ -66,7 +66,7 @@
       <div class="ml-[6.5rem] text-xs text-gray-600 mt-0.5 mb-1">
         {{ range .Lessons }}
         <div class="flex items-center gap-2">
-          <span>{{.ID}}</span>
+          <a class="text-blue-400 hover:text-blue-300" href="/lesson/{{.ID}}">{{.ID}}</a>
           <span class="text-gray-700">by</span>
           <span>{{.Teacher}}</span>
           <span class="text-gray-700">·</span>


### PR DESCRIPTION
## Summary
- Fix lesson list filter using system timezone instead of `PrimaryLoc`, which could hide today's lessons
- Make lesson IDs in the activity timeline clickable links to the lesson detail page

Closes #20

## Test plan
- [ ] Verify today's lessons appear in the filtered lesson list regardless of server timezone
- [ ] Verify lesson IDs in the activity timeline are clickable and navigate to the correct lesson page