### PR TITLE
Show today's past lessons in default dashboard view

### DIFF
--- a/src/handlers/user.go
+++ b/src/handlers/user.go
@@ -101,8 +101,9 @@ func UserInfoHandler(w http.ResponseWriter, r *http.Request) {
 		if showPast {
 			user.Lessons = lessons
 		} else {
+			startOfDay := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 			for _, l := range lessons {
-				if !l.DateTime.Before(now) {
+				if !l.DateTime.Before(startOfDay) {
 					user.Lessons = append(user.Lessons, l)
 				}
 			}


### PR DESCRIPTION
## Summary
- The default lessons list (with "show past" off) now includes all of today's lessons, even those already passed
- Filters against start of today (midnight) instead of current time

## Test plan
- [ ] Open dashboard without `showPast=true` — verify today's past lessons appear
- [ ] Toggle `[show past]` — verify all historical lessons still appear
- [ ] Check that tomorrow's and future lessons still appear in default view