### PR TITLE
Activity timeline, student queue, mobile layout, PostHog identify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ test-hurl:
 	hurl --test $(HURL_VARS) \
 		--variable student_id=student_$$(date +%s)13 \
 		tests/ui/task-markdown-rendering.hurl
+	hurl --test $(HURL_VARS) \
+		--variable student_id=student_$$(date +%s)15 \
+		tests/ui/lesson-student-queue-visibility.hurl
 
 # Build, start server with a temp DB, run Hurl tests, stop server.
 # Usage: make test-hurl-ci [TEST_PORT=18080] [TEACHER_ID=123]

--- a/src/handlers/lesson.go
+++ b/src/handlers/lesson.go
@@ -200,16 +200,6 @@ func LessonDetailHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if !user.IsTeacher {
-		filtered := visibleTaskRecords[:0]
-		for _, r := range visibleTaskRecords {
-			if r.StudentID == user.ID {
-				filtered = append(filtered, r)
-			}
-		}
-		visibleTaskRecords = filtered
-	}
-
 	renderPage(w, "templates/lesson.html", struct {
 		Lesson           *storage.Lesson
 		TeacherID        string
@@ -257,16 +247,6 @@ func LessonTaskRecordsPartialHandler(w http.ResponseWriter, r *http.Request) {
 		log.Printf("Error fetching task records for lesson %s: %v", lesson.ID, err)
 		http.Error(w, "Error fetching task records", http.StatusInternalServerError)
 		return
-	}
-
-	if !user.IsTeacher {
-		filtered := visibleTaskRecords[:0]
-		for _, r := range visibleTaskRecords {
-			if r.StudentID == user.ID {
-				filtered = append(filtered, r)
-			}
-		}
-		visibleTaskRecords = filtered
 	}
 
 	data := lessonRecordsData{

--- a/src/handlers/user.go
+++ b/src/handlers/user.go
@@ -146,17 +146,25 @@ type TimelineLesson struct {
 	ID         string
 	Registered int
 	Reviewed   int
+	Revoked    int
 	Teacher    string
 }
 
+type TimelineTeacherReview struct {
+	Teacher string
+	Checked int
+}
+
 type TimelineEntry struct {
-	Date       string // "Mon 02 Jan"
-	Checked    int    // teacher reviews that day (past only)
-	Lessons    []TimelineLesson
-	Registered int // total registered across all lessons (future only)
-	Reviewed   int // total reviewed across all lessons (future only)
-	IsToday    bool
-	IsFuture   bool
+	Date           string // "Mon 02 Jan"
+	Checked        int    // teacher reviews that day (past only)
+	Lessons        []TimelineLesson
+	TeacherReviews []TimelineTeacherReview
+	Registered     int // total registered across all lessons (future only)
+	Reviewed       int // total reviewed across all lessons (future only)
+	Revoked        int // total revoked across all lessons
+	IsToday        bool
+	IsFuture       bool
 }
 
 // UserListHandler shows all registered users with task summaries. Teacher-only.
@@ -176,6 +184,14 @@ func UserListHandler(w http.ResponseWriter, r *http.Request) {
 	now := time.Now().In(PrimaryLoc)
 	todayKey := now.Format("2006-01-02")
 	checkedByDay := make(map[string]int)
+
+	userNames := make(map[string]string) // userID -> username
+	for _, u := range users {
+		userNames[u.ID] = u.Username
+	}
+
+	// dayKey -> teacherID -> count
+	checkedByDayTeacher := make(map[string]map[string]int)
 
 	rows := make([]UserTableRow, 0, len(users))
 	for _, u := range users {
@@ -211,6 +227,10 @@ func UserListHandler(w http.ResponseWriter, r *http.Request) {
 						}
 						dayKey := rec.CreatedAt.In(PrimaryLoc).Format("2006-01-02")
 						checkedByDay[dayKey]++
+						if checkedByDayTeacher[dayKey] == nil {
+							checkedByDayTeacher[dayKey] = make(map[string]int)
+						}
+						checkedByDayTeacher[dayKey][rec.EntryAuthorID]++
 					}
 					switch rec.Status {
 					case storage.SubmitTaskRecord:
@@ -325,6 +345,7 @@ func UserListHandler(w http.ResponseWriter, r *http.Request) {
 			ID:         l.ID,
 			Registered: l.RegisteredCount(),
 			Reviewed:   l.ReviewedCount(),
+			Revoked:    l.RevokedCount(),
 			Teacher:    l.TeacherName,
 		})
 	}
@@ -332,10 +353,22 @@ func UserListHandler(w http.ResponseWriter, r *http.Request) {
 	timelineMap := make(map[string]*TimelineEntry)
 	for day, count := range checkedByDay {
 		isFuture := day > todayKey
+		var reviews []TimelineTeacherReview
+		for teacherID, c := range checkedByDayTeacher[day] {
+			name := userNames[teacherID]
+			if name == "" {
+				name = teacherID
+			}
+			reviews = append(reviews, TimelineTeacherReview{Teacher: name, Checked: c})
+		}
+		sort.Slice(reviews, func(i, j int) bool {
+			return reviews[i].Checked > reviews[j].Checked
+		})
 		e := &TimelineEntry{
-			Checked:  count,
-			IsToday:  day == todayKey,
-			IsFuture: isFuture,
+			Checked:        count,
+			TeacherReviews: reviews,
+			IsToday:        day == todayKey,
+			IsFuture:       isFuture,
 		}
 		timelineMap[day] = e
 	}
@@ -369,17 +402,25 @@ func UserListHandler(w http.ResponseWriter, r *http.Request) {
 		for _, l := range e.Lessons {
 			e.Registered += l.Registered
 			e.Reviewed += l.Reviewed
+			e.Revoked += l.Revoked
 		}
 		timeline = append(timeline, *e)
 	}
 
 	maxBar := 0
 	for _, e := range timeline {
-		if e.Checked > maxBar {
-			maxBar = e.Checked
+		var total int
+		if e.IsFuture {
+			total = e.Registered
+		} else {
+			queued := e.Registered - e.Reviewed
+			if queued < 0 {
+				queued = 0
+			}
+			total = e.Checked + queued
 		}
-		if e.Registered > maxBar {
-			maxBar = e.Registered
+		if total > maxBar {
+			maxBar = total
 		}
 	}
 

--- a/src/storage/lesson.go
+++ b/src/storage/lesson.go
@@ -63,6 +63,16 @@ func (l *Lesson) ReviewedCount() int {
 	return count
 }
 
+func (l *Lesson) RevokedCount() int {
+	count := 0
+	for _, t := range l.PreviousEnrolledTasks {
+		if t.Status == RevokedTaskRecord {
+			count++
+		}
+	}
+	return count
+}
+
 const lessonsKey = "lessons"
 
 func sortLessonsByDate(entries []*Lesson) {

--- a/src/util/template.go
+++ b/src/util/template.go
@@ -59,10 +59,12 @@ func GetRestText(s string, maxLen int) string {
 
 func FormatDateTime(fstName string, fstLoc *time.Location, sndName string, sndLoc *time.Location) func(time.Time) string {
 	return func(t time.Time) string {
-		return fmt.Sprintf("%s(%s) / %s(%s)",
-			t.In(fstLoc).Format("Mon 2.1.2006 15:04"),
+		return fmt.Sprintf("%s\u00a0%s(%s)/%s(%s)",
+			t.In(fstLoc).Format("Mon\u00a02.1.2006"),
+			t.In(fstLoc).Format("15:04"),
 			fstName,
-			t.In(sndLoc).Format("15:04"), sndName,
+			t.In(sndLoc).Format("15:04"),
+			sndName,
 		)
 	}
 }

--- a/templates/lesson.html
+++ b/templates/lesson.html
@@ -1,11 +1,13 @@
 {{define "title"}}Lesson - {{ formatDateTime .Lesson.DateTime }}{{end}}
 {{define "header"}}
-<span class="text-gray-500">·</span>
-<span>// @{{.Lesson.TeacherName}} · // lesson: {{ formatDateTime .Lesson.DateTime }}</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<span>//&nbsp;@{{.Lesson.TeacherName}}</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<span>//&nbsp;lesson:&nbsp;{{ formatDateTime .Lesson.DateTime }}</span>
 {{end}}
 {{define "footer_nav"}}
 {{ if eq .Lesson.TeacherID .SessionUserID }}
-<span class="text-gray-500">·</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
 <button class="text-red-400 hover:text-red-300 text-xs"
         type="button"
         data-action="delete-lesson"
@@ -14,7 +16,7 @@
   [delete]
 </button>
 {{ end }}
-<span class="text-gray-500">·</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
 <a class="text-blue-400 hover:text-blue-300" href="/logout">[logout]</a>
 {{end}}
 {{define "content"}}

--- a/templates/partials/layout.html
+++ b/templates/partials/layout.html
@@ -83,16 +83,43 @@
     </script>
   </head>
   <body class="bg-gray-900 text-gray-300 min-h-screen font-mono">
-    <header class="border-b border-gray-700 px-4 py-2 flex items-center justify-between text-xs">
-      <div class="flex items-center space-x-3">
-        <a class="text-gray-500 hover:text-gray-300" href="/">SLAP</a>
-        {{block "header" .}}{{end}} {{block "footer_nav" .}}{{end}}
-      </div>
-      <div class="flex items-center space-x-3 text-gray-600">
-        <div hx-trigger="load" hx-get="/parts/user-line">
+    <header class="border-b border-gray-700 px-4 py-2 text-xs">
+      <!-- large screen: single row -->
+      <div class="hidden sm:flex items-center justify-between">
+        <div class="flex items-center space-x-3">
+          <a class="text-gray-500 hover:text-gray-300" href="/">SLAP</a>
+          {{block "header" .}}{{end}} {{block "footer_nav" .}}{{end}}
         </div>
-        <span>v{{appVersion}} · up {{uptime}}</span>
-        <a class="hover:text-gray-400" href="https://github.com/ryukzak/slap">[github]</a>
+        <div class="flex items-center space-x-3 text-gray-600">
+          <div hx-trigger="load" hx-get="/parts/user-line">
+          </div>
+          <span class="text-gray-500">·</span>
+          <span>v{{appVersion}}</span>
+          <span class="text-gray-500">·</span>
+          <span>up {{uptime}}</span>
+          <a class="hover:text-gray-400" href="https://github.com/ryukzak/slap">[github]</a>
+        </div>
+      </div>
+      <!-- small screen: three columns -->
+      <div class="grid grid-cols-[auto_1fr_auto] gap-x-3 sm:hidden">
+        <div>
+          <a class="text-gray-500 hover:text-gray-300" href="/">SLAP</a>
+        </div>
+        <div class="flex flex-col">
+          <div>
+            {{block "header" .}}{{end}}
+          </div>
+          <div>
+            {{block "footer_nav" .}}{{end}}
+          </div>
+        </div>
+        <div class="flex flex-col items-end text-gray-600">
+          <div hx-trigger="load" hx-get="/parts/user-line">
+          </div>
+          <span>v{{appVersion}}</span>
+          <span>up {{uptime}}</span>
+          <a class="hover:text-gray-400" href="https://github.com/ryukzak/slap">[github]</a>
+        </div>
       </div>
     </header>
     <main class="container mx-auto px-4 pt-2 pb-4">

--- a/templates/partials/lesson_list.html
+++ b/templates/partials/lesson_list.html
@@ -8,13 +8,13 @@
   {{range .Lessons}}
   <li class="border-b border-gray-800 pb-1">
     {{if $.RegisterMode}}
-    <div class="text-xs flex items-center justify-between hover:bg-gray-800 py-1 px-1 rounded">
-      <div class="flex items-center space-x-2">
+    <div class="text-xs flex items-start sm:items-center justify-between hover:bg-gray-800 py-1 px-1 rounded">
+      <div class="flex flex-col sm:flex-row sm:items-center sm:space-x-2 min-w-0">
         <span>{{formatDateTime .DateTime}}</span>
         <span class="text-gray-500">@{{.TeacherName}}</span>
         <span class="text-gray-400 truncate min-w-0">{{getTitle .Description}}</span>
       </div>
-      <div class="flex items-center space-x-2">
+      <div class="flex items-center space-x-2 flex-shrink-0">
         <span class="text-gray-500">[{{.ReviewedCount}}/{{.RegisteredCount}}]</span>
         {{ if not .IsRegistrationOpen }}
         <span class="text-gray-500 text-xs">[closed]</span>
@@ -31,14 +31,14 @@
       </div>
     </div>
   {{else}}
-    <a class="block text-xs flex items-center justify-between hover:bg-gray-800 py-1 px-1 rounded"
+    <a class="block text-xs flex items-start sm:items-center justify-between hover:bg-gray-800 py-1 px-1 rounded"
        href="/lesson/{{.ID}}">
-      <div class="flex items-center space-x-2">
+      <div class="flex flex-col sm:flex-row sm:items-center sm:space-x-2 min-w-0">
         <span>{{formatDateTime .DateTime}}</span>
         <span class="text-gray-500">@{{.TeacherName}}</span>
         <span class="text-gray-400 truncate min-w-0">{{getTitle .Description}}</span>
       </div>
-      <div class="flex items-center space-x-2">
+      <div class="flex items-center space-x-2 flex-shrink-0">
         {{ if not .IsRegistrationOpen }}
         <span class="text-orange-400 text-xs">[closed]</span>
         {{ end }}

--- a/templates/partials/lesson_task_records.html
+++ b/templates/partials/lesson_task_records.html
@@ -26,6 +26,7 @@
       </div>
     </summary>
     <div class="px-4 pb-4 pt-2">
+      {{ if or $.SessionIsTeacher (eq $record.StudentID $.SessionUserID) }}
       {{ if and $.ShowRevoked $record.PreviousRecords }}
       <div class="mb-2">
         <div class="text-xs text-gray-500 mb-1">
@@ -72,6 +73,11 @@
       {{ end }}
     </div>
     {{ end }}
+  {{ else }}
+    <p class="text-xs text-gray-500">
+      Submission content is only visible to the author and teacher.
+    </p>
+    {{ end }}
     {{ if $.SessionIsTeacher }}
     <form class="lesson-review-form"
           hx-post="/user/{{$record.StudentID}}/task/{{$record.TaskID}}/journal"
@@ -96,7 +102,7 @@
         </div>
       </div>
     </form>
-  {{ else }}
+    {{ else if eq $record.StudentID $.SessionUserID }}
     <div class="flex justify-between mt-2">
       <div class="space-x-4">
         <a class="text-blue-400 hover:text-blue-300 text-xs"

--- a/templates/partials/user_line.html
+++ b/templates/partials/user_line.html
@@ -1,1 +1,6 @@
 {{.Roles}}
+<script>
+    if (window.posthog) {
+        posthog.identify("{{.ID}}");
+    }
+</script>

--- a/templates/reset.html
+++ b/templates/reset.html
@@ -1,9 +1,9 @@
 {{define "title"}}Reset Password{{end}}
 {{define "header"}}
-<span class="text-gray-500">·</span>
-<a class="text-gray-300 hover:text-white" href="/user/{{.UserID}}">// {{.Username}}</a>
-<span class="text-gray-500">·</span>
-<span>// reset password</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<a class="text-gray-300 hover:text-white" href="/user/{{.UserID}}">//&nbsp;{{.Username}}</a>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<span>//&nbsp;reset&nbsp;password</span>
 {{end}}
 {{define "content"}}
 <div class="container mx-auto p-4 max-w-lg">
@@ -50,8 +50,8 @@
 </div>
 {{end}}
 {{define "footer_nav"}}
-<span class="text-gray-500">·</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
 <a class="text-blue-400 hover:text-blue-300" href="/user/{{.UserID}}">[back]</a>
-<span class="text-gray-500">·</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
 <a class="text-blue-400 hover:text-blue-300" href="/logout">[logout]</a>
 {{end}}

--- a/templates/reset_request.html
+++ b/templates/reset_request.html
@@ -1,7 +1,7 @@
 {{define "title"}}Password Reset Request{{end}}
 {{define "header"}}
-<span class="text-gray-500">·</span>
-<span>// reset request</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<span>//&nbsp;reset&nbsp;request</span>
 {{end}}
 {{define "content"}}
 <div class="container mx-auto p-4 max-w-lg">

--- a/templates/reset_request_form.html
+++ b/templates/reset_request_form.html
@@ -1,7 +1,7 @@
 {{define "title"}}Password Reset Request{{end}}
 {{define "header"}}
-<span class="text-gray-500">·</span>
-<span>// reset request</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<span>//&nbsp;reset&nbsp;request</span>
 {{end}}
 {{define "content"}}
 <div class="container mx-auto p-4 max-w-lg">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,9 +1,9 @@
 {{define "title"}}Settings{{end}}
 {{define "header"}}
-<span class="text-gray-500">·</span>
-<a class="text-gray-300 hover:text-white" href="/user/{{.UserID}}">// me: {{.Username}}</a>
-<span class="text-gray-500">·</span>
-<span>// settings</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<a class="text-gray-300 hover:text-white" href="/user/{{.UserID}}">//&nbsp;me:&nbsp;{{.Username}}</a>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<span>//&nbsp;settings</span>
 {{end}}
 {{define "content"}}
 <div class="container mx-auto p-4 max-w-lg space-y-8">
@@ -81,8 +81,8 @@
 </div>
 {{end}}
 {{define "footer_nav"}}
-<span class="text-gray-500">·</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
 <a class="text-blue-400 hover:text-blue-300" href="/user/{{.UserID}}">[back]</a>
-<span class="text-gray-500">·</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
 <a class="text-blue-400 hover:text-blue-300" href="/logout">[logout]</a>
 {{end}}

--- a/templates/task.html
+++ b/templates/task.html
@@ -1,16 +1,16 @@
 {{define "title"}}{{.Title}} - Task Details{{end}}
 {{define "header"}}
-<span class="text-gray-500">·</span>
-<a class="text-gray-300 hover:text-white" href="/user/{{.StudentID}}">// {{ if eq .StudentID .SessionUserID }}me: {{ else }}student: {{ end }}{{.StudentName}}</a>
-<span class="text-gray-500">·</span>
-<span>// task: {{.Title}}</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<a class="text-gray-300 hover:text-white" href="/user/{{.StudentID}}">//&nbsp;{{ if eq .StudentID .SessionUserID }}me:&nbsp;{{ else }}student:&nbsp;{{ end }}{{.StudentName}}</a>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<span>//&nbsp;task:&nbsp;{{.Title}}</span>
 {{ if .Score }}
-<span class="text-gray-500">·</span>
-<span class="text-gray-300">score: {{.Score}}</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<span class="text-gray-300">score:&nbsp;{{.Score}}</span>
 {{ end }}
 {{end}}
 {{define "footer_nav"}}
-<span class="text-gray-500">·</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
 <a class="text-blue-400 hover:text-blue-300" href="/logout">[logout]</a>
 {{end}}
 {{define "content"}}

--- a/templates/token.html
+++ b/templates/token.html
@@ -1,7 +1,7 @@
 {{define "title"}}Your Access Token{{end}}
 {{define "header"}}
-<span class="text-gray-500">·</span>
-<span>// token</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<span>//&nbsp;token</span>
 {{end}}
 {{define "content"}}
 <div class="container mx-auto p-4 max-w-lg">
@@ -53,8 +53,8 @@
 </div>
 {{end}}
 {{define "footer_nav"}}
-<span class="text-gray-500">·</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
 <a class="text-blue-400 hover:text-blue-300" href="/user/{{.ID}}">[back]</a>
-<span class="text-gray-500">·</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
 <a class="text-blue-400 hover:text-blue-300" href="/logout">[logout]</a>
 {{end}}

--- a/templates/user.html
+++ b/templates/user.html
@@ -1,21 +1,21 @@
 {{define "title"}}User Profile{{end}}
 {{define "header"}}
-<span class="text-gray-500">·</span>
-<span>// {{ if eq .ID .SessionUserID }}me: {{ else if .SessionIsTeacher }}student: {{ end }}{{.Username}}</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<span>//&nbsp;{{ if eq .ID .SessionUserID }}me:&nbsp;{{ else if .SessionIsTeacher }}student:&nbsp;{{ end }}{{.Username}}</span>
 {{end}}
 {{define "footer_nav"}}
-<span class="text-gray-500">·</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
 {{ if .SessionIsTeacher }}
 <a class="text-blue-400 hover:text-blue-300" href="/users">[students]</a>
-<span class="text-gray-500">·</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
 {{ end }}
 {{ if eq .ID .SessionUserID }}
 <a class="text-blue-400 hover:text-blue-300"
    href="/user/{{.ID}}/settings">[settings]</a>
-<span class="text-gray-500">·</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
 {{ else if .SessionIsTeacher }}
 <a class="text-red-400 hover:text-red-300" href="/user/{{.ID}}/reset">[reset password]</a>
-<span class="text-gray-500">·</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
 {{ end }}
 <a class="text-blue-400 hover:text-blue-300" href="/logout">[logout]</a>
 {{end}}

--- a/templates/users.html
+++ b/templates/users.html
@@ -1,10 +1,10 @@
 {{define "title"}}Users - SLAP{{end}}
 {{define "header"}}
-<span class="text-gray-500">·</span>
-<span>// students</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<span>//&nbsp;students</span>
 {{end}}
 {{define "footer_nav"}}
-<span class="text-gray-500">·</span>
+<span class="text-gray-500 hidden sm:inline">·</span>
 <a class="text-blue-400 hover:text-blue-300" href="/logout">[logout]</a>
 {{end}}
 {{define "content"}}
@@ -19,7 +19,7 @@
     </summary>
     <div class="mt-2">
       {{ range .Timeline }}
-      {{ if .Lessons }}
+      {{ if or .Lessons .TeacherReviews }}
       <details class="mb-1">
       <summary class="flex items-center gap-2 text-xs cursor-pointer list-none {{ if .IsToday }}text-white{{ else if .IsFuture }}text-gray-400{{ else }}text-gray-500{{ end }}">
         <span class="w-24 shrink-0 font-mono">{{ if .IsToday }}*Today{{ else }}{{.Date}}{{ end }}</span>
@@ -40,7 +40,7 @@
             </div>
             {{ end }}
           </div>
-          <span class="shrink-0">l:{{len .Lessons}}&nbsp;q:{{.Registered}}&nbsp;c:{{.Reviewed}}</span>
+          <span class="shrink-0">l:{{len .Lessons}}&nbsp;q:{{.Registered}}&nbsp;c:{{.Reviewed}}{{ if .Revoked }}&nbsp;d:{{.Revoked}}{{ end }}</span>
         </div>
       {{ else }}
         <div class="flex items-center gap-2 flex-1 min-w-0">
@@ -59,7 +59,7 @@
             </div>
             {{ end }}
           </div>
-          <span class="shrink-0">l:{{len .Lessons}}&nbsp;q:{{sub .Registered .Reviewed}}&nbsp;c:{{.Checked}}</span>
+          <span class="shrink-0">l:{{len .Lessons}}&nbsp;q:{{sub .Registered .Reviewed}}&nbsp;c:{{.Checked}}{{ if .Revoked }}&nbsp;d:{{.Revoked}}{{ end }}</span>
         </div>
         {{ end }}
       </summary>
@@ -70,7 +70,16 @@
           <span class="text-gray-700">by</span>
           <span>{{.Teacher}}</span>
           <span class="text-gray-700">·</span>
-          <span>q:{{.Registered}}&nbsp;c:{{.Reviewed}}</span>
+          <span>q:{{.Registered}}&nbsp;c:{{.Reviewed}}{{ if .Revoked }}&nbsp;d:{{.Revoked}}{{ end }}</span>
+        </div>
+        {{ end }}
+        {{ range .TeacherReviews }}
+        <div class="flex items-center gap-2">
+          <span class="text-gray-600">review</span>
+          <span class="text-gray-700">by</span>
+          <span>{{.Teacher}}</span>
+          <span class="text-gray-700">·</span>
+          <span>c:{{.Checked}}</span>
         </div>
         {{ end }}
       </div>
@@ -95,7 +104,7 @@
         </div>
         {{ end }}
       </div>
-      <span class="shrink-0">l:{{len .Lessons}}&nbsp;q:{{.Registered}}&nbsp;c:{{.Reviewed}}</span>
+      <span class="shrink-0">l:{{len .Lessons}}&nbsp;q:{{.Registered}}&nbsp;c:{{.Reviewed}}{{ if .Revoked }}&nbsp;d:{{.Revoked}}{{ end }}</span>
     </div>
   {{ else }}
     <div class="flex items-center gap-2 flex-1 min-w-0">
@@ -114,7 +123,7 @@
         </div>
         {{ end }}
       </div>
-      <span class="shrink-0">l:{{len .Lessons}}&nbsp;q:{{sub .Registered .Reviewed}}&nbsp;c:{{.Checked}}</span>
+      <span class="shrink-0">l:{{len .Lessons}}&nbsp;q:{{sub .Registered .Reviewed}}&nbsp;c:{{.Checked}}{{ if .Revoked }}&nbsp;d:{{.Revoked}}{{ end }}</span>
     </div>
     {{ end }}
   </div>
@@ -124,7 +133,7 @@
     <span class="flex items-center gap-1"><span class="inline-block w-3 h-3 rounded bg-green-800"></span> reviewed</span>
     <span class="flex items-center gap-1"><span class="inline-block w-3 h-3 rounded bg-yellow-700"></span> queued</span>
     <span class="flex-1"></span>
-    <span>l:lessons q:queued c:checked</span>
+    <span>l:lessons q:queued c:checked d:dropped</span>
   </div>
 </div>
 </details>

--- a/tests/run-hurl.sh
+++ b/tests/run-hurl.sh
@@ -97,6 +97,9 @@ run_test tests/ui/dashboard-role-sections.hurl \
 run_test tests/ui/task-markdown-rendering.hurl \
     --variable "student_id=${TIMESTAMP}13"
 
+run_test tests/ui/lesson-student-queue-visibility.hurl \
+    --variable "student_id=${TIMESTAMP}15"
+
 # Stop server
 kill "$SERVER_PID" 2>/dev/null
 rm -f "$TEST_DB"

--- a/tests/settings-flow.hurl
+++ b/tests/settings-flow.hurl
@@ -27,7 +27,7 @@ Cookie: user_data={{student_token}}
 
 HTTP 200
 [Asserts]
-body contains "// settings"
+body contains "//&nbsp;settings"
 body contains "Settings Student"
 
 # Step 3: Change display name

--- a/tests/ui/lesson-student-queue-visibility.hurl
+++ b/tests/ui/lesson-student-queue-visibility.hurl
@@ -1,0 +1,142 @@
+# Lesson Student Queue Visibility Test
+# Tests: student can see other students' entries in the lesson queue,
+#        but cannot see the submitted content of other students.
+#
+# Prerequisites: server running against a fresh DB with default config
+#   (teacher_ids: ["123"]).
+
+# Step 1: Sign in as teacher
+POST {{base_url}}/signin
+[Options]
+variable: teacher_password=TeacherPass123!
+variable: student_a_password=StudentAPass123!
+variable: student_a_username=AliceQueue
+variable: student_b_password=StudentBPass123!
+variable: student_b_username=BobQueue
+variable: student_b_id={{student_id}}1
+variable: task_id=task1
+[FormParams]
+id: {{teacher_id}}
+password: {{teacher_password}}
+
+HTTP 303
+[Captures]
+teacher_token: cookie "user_data"
+
+GET {{base_url}}/logout
+HTTP 303
+
+# Step 2: Teacher creates a lesson
+POST {{base_url}}/api/lessons
+Cookie: user_data={{teacher_token}}
+[Options]
+location: true
+[FormParams]
+date: 2099-12-31
+time: 14:00
+description: Queue visibility test lesson
+
+HTTP 200
+[Captures]
+lesson_id: url regex "/lesson/([^/?#]+)"
+
+# Step 3: Sign up student A
+POST {{base_url}}/signup
+[FormParams]
+id: {{student_id}}
+password: {{student_a_password}}
+username: {{student_a_username}}
+
+HTTP 303
+[Captures]
+student_a_token: cookie "user_data"
+
+GET {{base_url}}/logout
+HTTP 303
+
+# Step 4: Student A submits and registers a task
+POST {{base_url}}/user/{{student_id}}/task/{{task_id}}/journal
+Cookie: user_data={{student_a_token}}
+[FormParams]
+content: Alice secret submission content
+
+HTTP 303
+
+POST {{base_url}}/api/lesson/{{lesson_id}}/register
+Cookie: user_data={{student_a_token}}
+[FormParams]
+taskRecordID: {{task_id}}
+studentID: {{student_id}}
+
+HTTP 200
+
+# Step 5: Sign up student B
+POST {{base_url}}/signup
+[FormParams]
+id: {{student_b_id}}
+password: {{student_b_password}}
+username: {{student_b_username}}
+
+HTTP 303
+[Captures]
+student_b_token: cookie "user_data"
+
+GET {{base_url}}/logout
+HTTP 303
+
+# Step 6: Student B submits and registers a task
+POST {{base_url}}/user/{{student_b_id}}/task/{{task_id}}/journal
+Cookie: user_data={{student_b_token}}
+[FormParams]
+content: Bob secret submission content
+
+HTTP 303
+
+POST {{base_url}}/api/lesson/{{lesson_id}}/register
+Cookie: user_data={{student_b_token}}
+[FormParams]
+taskRecordID: {{task_id}}
+studentID: {{student_b_id}}
+
+HTTP 200
+
+# Step 7: Student A views lesson page - sees both students in queue
+GET {{base_url}}/lesson/{{lesson_id}}
+Cookie: user_data={{student_a_token}}
+
+HTTP 200
+[Asserts]
+body contains "@AliceQueue"
+body contains "@BobQueue"
+body contains "Queued"
+# Student A sees own submission content
+body contains "Alice secret submission content"
+# Student A does NOT see student B's submission content
+body not contains "Bob secret submission content"
+# Student A sees placeholder for other's content
+body contains "Submission content is only visible to the author and teacher."
+
+# Step 8: Student B views lesson page - sees both students but not A's content
+GET {{base_url}}/lesson/{{lesson_id}}
+Cookie: user_data={{student_b_token}}
+
+HTTP 200
+[Asserts]
+body contains "@AliceQueue"
+body contains "@BobQueue"
+body contains "Queued"
+# Student B sees own submission content
+body contains "Bob secret submission content"
+# Student B does NOT see student A's submission content
+body not contains "Alice secret submission content"
+
+# Step 9: Teacher still sees all content
+GET {{base_url}}/lesson/{{lesson_id}}
+Cookie: user_data={{teacher_token}}
+
+HTTP 200
+[Asserts]
+body contains "@AliceQueue"
+body contains "@BobQueue"
+body contains "Alice secret submission content"
+body contains "Bob secret submission content"


### PR DESCRIPTION
## Summary
- **Activity timeline**: show teacher attribution for reviews, normalize bar widths, display revoked task count
- **Student lesson queue**: students see the full queue (who's next, who passed) but not other students' submission content
- **PostHog session replay**: link frontend recordings to backend user profiles via `posthog.identify`
- **Responsive mobile layout**: three-column header on small screens, stacked lesson list items, non-breaking spaces in page names
- **Unified date/time format**: `Sun 22.3.2026 12:00(MSK)/10:00(CET)` with non-breaking spaces

## Test plan
- [x] All existing hurl integration tests pass
- [x] New `lesson-student-queue-visibility.hurl` test covers student queue visibility rules
- [ ] Manually verify mobile layout on narrow viewport
- [ ] Verify PostHog session replays show identified users