### PR TITLE
Add register-ord sort mode to lesson page

### DIFF
--- a/src/handlers/lesson.go
+++ b/src/handlers/lesson.go
@@ -187,6 +187,10 @@ func buildLessonRecords(lesson *storage.Lesson, showRevoked bool, sortMode SortM
 	}
 
 	switch sortMode {
+	case SortByRegisterOrd:
+		sort.SliceStable(visible, func(i, j int) bool {
+			return registeredAtOrCreated(visible[i]).Before(registeredAtOrCreated(visible[j]))
+		})
 	case SortByTaskMix:
 		visible = util.InterleaveByKey(visible, func(r TaskRecordWithInfo) string { return string(r.TaskID) })
 	case SortByStudentMix:
@@ -573,4 +577,11 @@ func reverseSlice(s []storage.TaskRecord) []storage.TaskRecord {
 	c := slices.Clone(s)
 	slices.Reverse(c)
 	return c
+}
+
+func registeredAtOrCreated(r TaskRecordWithInfo) time.Time {
+	if !r.RegisteredAt.IsZero() {
+		return r.RegisteredAt
+	}
+	return r.CreatedAt
 }

--- a/src/handlers/sort.go
+++ b/src/handlers/sort.go
@@ -4,15 +4,16 @@ package handlers
 type SortMode string
 
 const (
-	SortBySubmitOrd  SortMode = "submit-ord"
-	SortByTaskMix    SortMode = "task-mix"
-	SortByStudentMix SortMode = "student-mix"
+	SortBySubmitOrd   SortMode = "submit-ord"
+	SortByRegisterOrd SortMode = "register-ord"
+	SortByTaskMix     SortMode = "task-mix"
+	SortByStudentMix  SortMode = "student-mix"
 )
 
-// ParseSortMode returns a valid SortMode from a string, defaulting to date.
+// ParseSortMode returns a valid SortMode from a string, defaulting to submit-ord.
 func ParseSortMode(s string) SortMode {
 	switch SortMode(s) {
-	case SortByTaskMix, SortByStudentMix:
+	case SortByRegisterOrd, SortByTaskMix, SortByStudentMix:
 		return SortMode(s)
 	default:
 		return SortBySubmitOrd

--- a/src/handlers/sort_test.go
+++ b/src/handlers/sort_test.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,7 @@ func TestParseSortMode_Valid(t *testing.T) {
 		want  SortMode
 	}{
 		{"submit-ord", SortBySubmitOrd},
+		{"register-ord", SortByRegisterOrd},
 		{"task-mix", SortByTaskMix},
 		{"student-mix", SortByStudentMix},
 	}
@@ -57,6 +59,12 @@ func makeRecords(regs []reg) []TaskRecordWithInfo {
 
 func applySortMode(records []TaskRecordWithInfo, mode SortMode) []TaskRecordWithInfo {
 	switch mode {
+	case SortByRegisterOrd:
+		out := append([]TaskRecordWithInfo(nil), records...)
+		sort.SliceStable(out, func(i, j int) bool {
+			return registeredAtOrCreated(out[i]).Before(registeredAtOrCreated(out[j]))
+		})
+		return out
 	case SortByTaskMix:
 		return util.InterleaveByKey(records, func(r TaskRecordWithInfo) string { return string(r.TaskID) })
 	case SortByStudentMix:
@@ -142,4 +150,47 @@ func TestSortModes(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSortByRegisterOrd(t *testing.T) {
+	base := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	mk := func(student, task string, createdMin, registeredMin int) TaskRecordWithInfo {
+		r := TaskRecordWithInfo{
+			TaskRecord: storage.TaskRecord{
+				TaskID:    storage.TaskID(task),
+				StudentID: storage.UserID(student),
+				CreatedAt: base.Add(time.Duration(createdMin) * time.Minute),
+			},
+		}
+		if registeredMin >= 0 {
+			r.RegisteredAt = base.Add(time.Duration(registeredMin) * time.Minute)
+		}
+		return r
+	}
+
+	t.Run("orders by RegisteredAt regardless of CreatedAt", func(t *testing.T) {
+		input := []TaskRecordWithInfo{
+			mk("Alice", "T1", 1, 30), // submitted early, registered late
+			mk("Bob", "T2", 2, 10),   // submitted mid, registered first
+			mk("Carol", "T3", 3, 20), // submitted late, registered mid
+		}
+		got := formatSequence(applySortMode(input, SortByRegisterOrd))
+		want := "Bob:T2 Carol:T3 Alice:T1"
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("falls back to CreatedAt when RegisteredAt is zero", func(t *testing.T) {
+		input := []TaskRecordWithInfo{
+			mk("Alice", "T1", 5, -1), // no RegisteredAt -> uses CreatedAt=5
+			mk("Bob", "T2", 1, 10),   // RegisteredAt=10
+			mk("Carol", "T3", 9, 2),  // RegisteredAt=2
+		}
+		got := formatSequence(applySortMode(input, SortByRegisterOrd))
+		want := "Carol:T3 Alice:T1 Bob:T2"
+		if got != want {
+			t.Errorf("expected %q, got %q", want, got)
+		}
+	})
 }

--- a/templates/lesson.html
+++ b/templates/lesson.html
@@ -164,6 +164,12 @@
       <a class="text-blue-400 hover:text-blue-300"
          href="?showRevoked={{.ShowRevoked}}&sort=submit-ord">submit-ord</a>
       {{ end }}
+      {{ if eq (printf "%s" .SortMode) "register-ord" }}
+      register-ord
+    {{ else }}
+      <a class="text-blue-400 hover:text-blue-300"
+         href="?showRevoked={{.ShowRevoked}}&sort=register-ord">register-ord</a>
+      {{ end }}
       {{ if eq (printf "%s" .SortMode) "task-mix" }}
       task-mix
     {{ else }}


### PR DESCRIPTION
## Summary
- New `register-ord` sort mode on the lesson page, alongside the existing `submit-ord`, `task-mix`, and `student-mix` options.
- Orders visible task records by `RegisteredAt` (when the student registered the task to *this* lesson), with a fallback to `CreatedAt` for records that lack a registration timestamp (e.g. historic / revoked entries).
- UI toggle is wired into `templates/lesson.html` between `submit-ord` and `task-mix`; the htmx partial honours the new `sort` query value.

## Test plan
- [x] `go test ./src/handlers/...` — new `TestSortByRegisterOrd` covers the ordering and the zero-`RegisteredAt` fallback; `ParseSortMode` tests extended.
- [x] `make format-check lint` clean.
- [ ] Manual: open a lesson, click `register-ord`, confirm queue is ordered by registration time and the link toggle highlights correctly. Verify the htmx refresh after registering/revoking preserves the selected sort.