### PR TITLE
Add /teachers page and show days in header uptime

### DIFF
--- a/main.go
+++ b/main.go
@@ -141,10 +141,7 @@ func init() {
 		},
 		"appVersion": func() string { return version },
 		"uptime": func() string {
-			d := time.Since(handlers.StartTime)
-			h := int(d.Hours())
-			m := int(d.Minutes()) % 60
-			return fmt.Sprintf("%dh%02dm", h, m)
+			return util.FormatUptime(time.Since(handlers.StartTime))
 		},
 	}
 
@@ -225,6 +222,7 @@ func main() {
 	// User and task routes with specific path prefixes
 	r.HandleFunc("/users", handlers.UserListHandler).Methods("GET")
 	r.HandleFunc("/users/csv", handlers.UserListCSVHandler).Methods("GET")
+	r.HandleFunc("/teachers", handlers.TeacherListHandler).Methods("GET")
 	r.HandleFunc("/user/{userID}", handlers.UserInfoHandler).Methods("GET")
 	r.HandleFunc("/user/{userID}/task/{taskID}", handlers.TaskDetailHandler).Methods("GET")
 	r.HandleFunc("/user/{userID}/task/{taskID}/journal", handlers.AddTaskRecordHandler).Methods("POST")

--- a/src/handlers/teachers.go
+++ b/src/handlers/teachers.go
@@ -1,0 +1,120 @@
+package handlers
+
+import (
+	"log"
+	"net/http"
+	"sort"
+	"time"
+
+	"github.com/ryukzak/slap/src/storage"
+)
+
+type TeacherRow struct {
+	ID         storage.UserID
+	Username   string
+	Lessons    int
+	Reviews    int
+	Queued     int
+	LastLesson *time.Time
+	NextLesson *time.Time
+}
+
+func TeacherListHandler(w http.ResponseWriter, r *http.Request) {
+	sessionUser := teacherSession(w, r)
+	if sessionUser == nil {
+		return
+	}
+
+	users, err := DB.ListUsers()
+	if err != nil {
+		log.Printf("Error listing users: %v", err)
+		http.Error(w, "Failed to list users", http.StatusInternalServerError)
+		return
+	}
+
+	lessons, err := DB.ListLessons()
+	if err != nil {
+		log.Printf("Error listing lessons: %v", err)
+		http.Error(w, "Failed to list lessons", http.StatusInternalServerError)
+		return
+	}
+
+	teachers := make(map[storage.UserID]*TeacherRow)
+	for _, u := range users {
+		if !u.IsTeacher {
+			continue
+		}
+		teachers[u.ID] = &TeacherRow{ID: u.ID, Username: u.Username}
+	}
+
+	now := time.Now()
+	for _, l := range lessons {
+		t, ok := teachers[l.TeacherID]
+		if !ok {
+			// Lessons authored by a non-teacher user (role revoked etc.) — surface anyway.
+			t = &TeacherRow{ID: l.TeacherID, Username: l.TeacherName}
+			teachers[l.TeacherID] = t
+		}
+		t.Lessons++
+		for _, e := range l.EnrolledTasks {
+			if e.Status == storage.RegisterTaskRecord {
+				t.Queued++
+			}
+		}
+		when := l.DateTime
+		if when.Before(now) {
+			if t.LastLesson == nil || when.After(*t.LastLesson) {
+				cp := when
+				t.LastLesson = &cp
+			}
+		} else {
+			if t.NextLesson == nil || when.Before(*t.NextLesson) {
+				cp := when
+				t.NextLesson = &cp
+			}
+		}
+	}
+
+	for _, u := range users {
+		if !u.IsStudent {
+			continue
+		}
+		for _, task := range AppConfig.Tasks {
+			records, err := DB.ListTaskRecords(u.ID, task.ID)
+			if err != nil {
+				log.Printf("Error fetching task records for user %s task %s: %v", u.ID, task.ID, err)
+				continue
+			}
+			for _, rec := range records {
+				if rec.EntryAuthorID == rec.StudentID {
+					continue
+				}
+				if t, ok := teachers[rec.EntryAuthorID]; ok {
+					t.Reviews++
+				}
+			}
+		}
+	}
+
+	rows := make([]*TeacherRow, 0, len(teachers))
+	for _, t := range teachers {
+		rows = append(rows, t)
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Lessons != rows[j].Lessons {
+			return rows[i].Lessons > rows[j].Lessons
+		}
+		if rows[i].Reviews != rows[j].Reviews {
+			return rows[i].Reviews > rows[j].Reviews
+		}
+		return rows[i].Username < rows[j].Username
+	})
+
+	renderPage(w, "templates/teachers.html", struct {
+		SessionUserID string
+		Teachers      []*TeacherRow
+	}{
+		SessionUserID: sessionUser.ID,
+		Teachers:      rows,
+	})
+}

--- a/src/util/template.go
+++ b/src/util/template.go
@@ -57,6 +57,22 @@ func GetRestText(s string, maxLen int) string {
 	return string(runes[maxLen:])
 }
 
+// FormatUptime renders a duration as "Hh%02dm" when under a day, and prepends
+// "Xd" once the duration reaches 24h (e.g. "2d5h12m").
+func FormatUptime(d time.Duration) string {
+	if d < 0 {
+		d = 0
+	}
+	days := int(d / (24 * time.Hour))
+	rem := d - time.Duration(days)*24*time.Hour
+	h := int(rem.Hours())
+	m := int(rem.Minutes()) % 60
+	if days > 0 {
+		return fmt.Sprintf("%dd%dh%02dm", days, h, m)
+	}
+	return fmt.Sprintf("%dh%02dm", h, m)
+}
+
 func FormatDateTime(fstName string, fstLoc *time.Location, sndName string, sndLoc *time.Location) func(time.Time) string {
 	return func(t time.Time) string {
 		return fmt.Sprintf("%s\u00a0%s(%s)/%s(%s)",

--- a/src/util/template_test.go
+++ b/src/util/template_test.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"testing"
+	"time"
+)
+
+func TestFormatUptime(t *testing.T) {
+	tests := []struct {
+		name string
+		in   time.Duration
+		want string
+	}{
+		{"zero", 0, "0h00m"},
+		{"sub-hour", 7 * time.Minute, "0h07m"},
+		{"hours only", 5*time.Hour + 12*time.Minute, "5h12m"},
+		{"exactly one day", 24 * time.Hour, "1d0h00m"},
+		{"days and hours", 2*24*time.Hour + 5*time.Hour + 12*time.Minute, "2d5h12m"},
+		{"days, no extra hours", 3*24*time.Hour + 7*time.Minute, "3d0h07m"},
+		{"negative clamps to zero", -time.Hour, "0h00m"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FormatUptime(tt.in); got != tt.want {
+				t.Errorf("FormatUptime(%v) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/templates/teachers.html
+++ b/templates/teachers.html
@@ -1,0 +1,72 @@
+{{define "title"}}Teachers - SLAP{{end}}
+{{define "header"}}
+<span class="text-gray-500 hidden sm:inline">·</span>
+<span>//&nbsp;teachers</span>
+{{end}}
+{{define "footer_nav"}}
+<span class="text-gray-500 hidden sm:inline">·</span>
+<a class="text-blue-400 hover:text-blue-300" href="/users">[students]</a>
+<span class="text-gray-500 hidden sm:inline">·</span>
+<a class="text-blue-400 hover:text-blue-300" href="/logout">[logout]</a>
+{{end}}
+{{define "content"}}
+<section class="mb-8">
+  <div class="text-xs text-gray-500 mb-2">
+    // teachers ({{ len .Teachers }})
+  </div>
+  {{ if .Teachers }}
+  <table class="w-full text-xs border-collapse">
+    <thead>
+      <tr class="border-b border-gray-700">
+        <th class="text-left text-gray-400 py-1 pr-4 font-normal">
+          teacher
+        </th>
+        <th class="text-right text-gray-400 py-1 px-2 font-normal">
+          lessons
+        </th>
+        <th class="text-right text-gray-400 py-1 px-2 font-normal">
+          reviews
+        </th>
+        <th class="text-right text-gray-400 py-1 px-2 font-normal">
+          queued
+        </th>
+        <th class="text-left text-gray-400 py-1 px-2 font-normal">
+          last lesson
+        </th>
+        <th class="text-left text-gray-400 py-1 pl-2 font-normal">
+          next lesson
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+      {{ range .Teachers }}
+      <tr class="border-b border-gray-800">
+        <td class="py-1 pr-4">
+          <a class="text-blue-400 hover:text-blue-300" href="/user/{{.ID}}">@{{.Username}}</a>
+        </td>
+      <td class="py-1 px-2 text-right {{ if .Lessons }}text-gray-300{{ else }}text-gray-700{{ end }}">
+        {{.Lessons}}
+      </td>
+    <td class="py-1 px-2 text-right {{ if .Reviews }}text-green-400{{ else }}text-gray-700{{ end }}">
+      {{.Reviews}}
+    </td>
+  <td class="py-1 px-2 text-right {{ if .Queued }}text-yellow-400{{ else }}text-gray-700{{ end }}">
+    {{.Queued}}
+  </td>
+  <td class="py-1 px-2 text-gray-400">
+    {{ with .LastLesson }}{{ formatDateTime . }}{{ else }}<span class="text-gray-700">—</span>{{ end }}
+  </td>
+  <td class="py-1 pl-2 text-gray-400">
+    {{ with .NextLesson }}{{ formatDateTime . }}{{ else }}<span class="text-gray-700">—</span>{{ end }}
+  </td>
+</tr>
+{{ end }}
+</tbody>
+</table>
+{{ else }}
+<p class="text-xs text-gray-400 p-4 border border-gray-800 rounded">
+  No teachers yet.
+</p>
+{{ end }}
+</section>
+{{end}}

--- a/templates/user.html
+++ b/templates/user.html
@@ -8,6 +8,8 @@
 {{ if .SessionIsTeacher }}
 <a class="text-blue-400 hover:text-blue-300" href="/users">[students]</a>
 <span class="text-gray-500 hidden sm:inline">·</span>
+<a class="text-blue-400 hover:text-blue-300" href="/teachers">[teachers]</a>
+<span class="text-gray-500 hidden sm:inline">·</span>
 {{ end }}
 {{ if eq .ID .SessionUserID }}
 <a class="text-blue-400 hover:text-blue-300"

--- a/templates/users.html
+++ b/templates/users.html
@@ -5,6 +5,8 @@
 {{end}}
 {{define "footer_nav"}}
 <span class="text-gray-500 hidden sm:inline">·</span>
+<a class="text-blue-400 hover:text-blue-300" href="/teachers">[teachers]</a>
+<span class="text-gray-500 hidden sm:inline">·</span>
 <a class="text-blue-400 hover:text-blue-300" href="/logout">[logout]</a>
 {{end}}
 {{define "content"}}


### PR DESCRIPTION
## Summary
- **`/teachers` page** (teacher-only) with a compact table of all teachers — columns: teacher (link), lessons, reviews authored, queued enrollments in their lessons, last lesson, next lesson. Sorted by lessons desc, then reviews desc, then username. Linked from `/users` and the user-profile footer nav (for teachers).
- **Header uptime** now prepends `Xd` once runtime reaches 24h, e.g. `2d5h12m`; sub-day uptimes keep the existing `5h12m`. The formatter is extracted into `src/util.FormatUptime` and unit-tested.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` clean — new `TestFormatUptime` covers sub-hour / hours / day-boundary / multi-day / negative-clamp cases.
- [x] `make format-check lint` clean (djlint reformatted `teachers.html` to match repo style).
- [x] `make test-hurl-ci` — all existing hurl tests pass.
- [ ] Manual: sign in as a teacher, hit `/teachers`, confirm rows render, counts look right, and links route to `/user/{id}`.
- [ ] Manual: sign in as a student and confirm `/teachers` 403s (teacher-only guard).

## Notes
- "Reviews" counts task records authored by the teacher where author ≠ student — same metric the existing `/users` timeline already aggregates, so it should match the per-day teacher reviewer counts already shown there.
- Teachers with no lessons still appear (count = 0). Lessons authored by a user whose `IsTeacher` flag was later revoked still surface in the table under their stored `TeacherName`.
- Happy to tweak columns/sort order — easy to add e.g. "reviewed-in-own-lessons" or split last/next into separate columns if you'd prefer.