### PR TITLE
Open external markdown links in a new tab

### DIFF
--- a/src/util/markdown.go
+++ b/src/util/markdown.go
@@ -9,7 +9,11 @@ import (
 	"github.com/microcosm-cc/bluemonday"
 )
 
-var policy = bluemonday.UGCPolicy()
+var policy = func() *bluemonday.Policy {
+	p := bluemonday.UGCPolicy()
+	p.AddTargetBlankToFullyQualifiedLinks(true)
+	return p
+}()
 
 func RenderMarkdown(input string) template.HTML {
 	extensions := parser.CommonExtensions | parser.AutoHeadingIDs | parser.NoEmptyLineBeforeBlock | parser.Autolink

--- a/src/util/markdown_test.go
+++ b/src/util/markdown_test.go
@@ -1,0 +1,29 @@
+package util
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRenderMarkdown_AbsoluteLinkOpensInNewTab(t *testing.T) {
+	got := string(RenderMarkdown("see [docs](https://example.com/page)"))
+	if !strings.Contains(got, `href="https://example.com/page"`) {
+		t.Fatalf("expected absolute href, got: %s", got)
+	}
+	if !strings.Contains(got, `target="_blank"`) {
+		t.Errorf("expected target=\"_blank\" on absolute link, got: %s", got)
+	}
+	if !strings.Contains(got, `rel=`) || !strings.Contains(got, "noopener") {
+		t.Errorf("expected rel with noopener on absolute link, got: %s", got)
+	}
+}
+
+func TestRenderMarkdown_RelativeLinkStaysInSameTab(t *testing.T) {
+	got := string(RenderMarkdown("see [profile](/user/42)"))
+	if !strings.Contains(got, `href="/user/42"`) {
+		t.Fatalf("expected relative href, got: %s", got)
+	}
+	if strings.Contains(got, `target="_blank"`) {
+		t.Errorf("did not expect target=\"_blank\" on relative link, got: %s", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Markdown-rendered absolute links (anything with a scheme — `https://…`, etc.) now open in a new tab. Implemented by enabling bluemonday's `AddTargetBlankToFullyQualifiedLinks`, which also adds a safe `rel="nofollow noopener"`.
- Relative links (`/user/…`, `/lesson/…`) keep their current same-tab behavior.
- Applies everywhere `util.RenderMarkdown` is used: task submissions, reviews, lesson descriptions, etc.

## Test plan
- [x] `go test ./...` — new `TestRenderMarkdown_AbsoluteLinkOpensInNewTab` and `TestRenderMarkdown_RelativeLinkStaysInSameTab` cover both cases.
- [x] `make format-check lint` clean.
- [ ] Manual: open a task with a markdown body containing an external link; confirm it opens in a new tab and that links to other SLAP pages still navigate in-place.