### PR TITLE
Add sort by lessons/reviews on teachers page

### DIFF
--- a/src/handlers/teachers.go
+++ b/src/handlers/teachers.go
@@ -19,6 +19,22 @@ type TeacherRow struct {
 	NextLesson *time.Time
 }
 
+type TeacherSortMode string
+
+const (
+	TeacherSortByLessons TeacherSortMode = "lessons"
+	TeacherSortByReviews TeacherSortMode = "reviews"
+)
+
+func ParseTeacherSortMode(s string) TeacherSortMode {
+	switch TeacherSortMode(s) {
+	case TeacherSortByReviews:
+		return TeacherSortByReviews
+	default:
+		return TeacherSortByLessons
+	}
+}
+
 func TeacherListHandler(w http.ResponseWriter, r *http.Request) {
 	sessionUser := teacherSession(w, r)
 	if sessionUser == nil {
@@ -100,21 +116,36 @@ func TeacherListHandler(w http.ResponseWriter, r *http.Request) {
 	for _, t := range teachers {
 		rows = append(rows, t)
 	}
+
+	sortMode := ParseTeacherSortMode(r.URL.Query().Get("sort"))
 	sort.Slice(rows, func(i, j int) bool {
-		if rows[i].Lessons != rows[j].Lessons {
-			return rows[i].Lessons > rows[j].Lessons
+		a, b := rows[i], rows[j]
+		switch sortMode {
+		case TeacherSortByReviews:
+			if a.Reviews != b.Reviews {
+				return a.Reviews > b.Reviews
+			}
+			if a.Lessons != b.Lessons {
+				return a.Lessons > b.Lessons
+			}
+		default:
+			if a.Lessons != b.Lessons {
+				return a.Lessons > b.Lessons
+			}
+			if a.Reviews != b.Reviews {
+				return a.Reviews > b.Reviews
+			}
 		}
-		if rows[i].Reviews != rows[j].Reviews {
-			return rows[i].Reviews > rows[j].Reviews
-		}
-		return rows[i].Username < rows[j].Username
+		return a.Username < b.Username
 	})
 
 	renderPage(w, "templates/teachers.html", struct {
 		SessionUserID string
 		Teachers      []*TeacherRow
+		SortMode      TeacherSortMode
 	}{
 		SessionUserID: sessionUser.ID,
 		Teachers:      rows,
+		SortMode:      sortMode,
 	})
 }

--- a/src/handlers/teachers_test.go
+++ b/src/handlers/teachers_test.go
@@ -1,0 +1,21 @@
+package handlers
+
+import "testing"
+
+func TestParseTeacherSortMode(t *testing.T) {
+	tests := []struct {
+		in   string
+		want TeacherSortMode
+	}{
+		{"lessons", TeacherSortByLessons},
+		{"reviews", TeacherSortByReviews},
+		{"", TeacherSortByLessons},
+		{"unknown", TeacherSortByLessons},
+		{"LESSONS", TeacherSortByLessons},
+	}
+	for _, tt := range tests {
+		if got := ParseTeacherSortMode(tt.in); got != tt.want {
+			t.Errorf("ParseTeacherSortMode(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}

--- a/templates/teachers.html
+++ b/templates/teachers.html
@@ -22,10 +22,18 @@
           teacher
         </th>
         <th class="text-right text-gray-400 py-1 px-2 font-normal">
-          lessons
+          {{ if eq (printf "%s" .SortMode) "lessons" }}
+          <span class="text-gray-200">lessons&nbsp;↓</span>
+        {{ else }}
+          <a class="text-blue-400 hover:text-blue-300" href="?sort=lessons">lessons</a>
+          {{ end }}
         </th>
         <th class="text-right text-gray-400 py-1 px-2 font-normal">
-          reviews
+          {{ if eq (printf "%s" .SortMode) "reviews" }}
+          <span class="text-gray-200">reviews&nbsp;↓</span>
+        {{ else }}
+          <a class="text-blue-400 hover:text-blue-300" href="?sort=reviews">reviews</a>
+          {{ end }}
         </th>
         <th class="text-right text-gray-400 py-1 px-2 font-normal">
           queued


### PR DESCRIPTION
## Summary
- Make the `lessons` and `reviews` column headers on `/teachers` clickable. The currently active column is rendered as plain text with a `↓` marker; the other column is a `[blue link]` to switch. Default (no `?sort`) stays as `lessons` desc.
- Handler reads `?sort=lessons|reviews`, falls back to `lessons` for empty/unknown values, and uses the other metric as the tiebreaker (then username asc).
- This commit was originally pushed to the `teacher-page-and-uptime-days` branch after PR #37 had already been merged, so it never reached master — cherry-picking it cleanly onto a fresh branch.

## Test plan
- [x] `go test ./...` — `TestParseTeacherSortMode` covers valid, empty, unknown, and wrong-case inputs.
- [x] `make format-check lint` clean.
- [ ] Manual: open `/teachers`, confirm `lessons` is the active label by default; click `reviews`, confirm rows resort and the `↓` marker moves; click `lessons` again to switch back.