### PR TITLE
Re-registration after revoke

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,12 @@ test-hurl:
 		tests/ui/lesson-student-queue-visibility.hurl
 	hurl --test $(HURL_VARS) \
 		tests/ui/lesson-preview-unauthenticated.hurl
+	hurl --test $(HURL_VARS) \
+		--variable student_id=student_$$(date +%s)16 \
+		tests/ui/reregistration-after-revoke.hurl
+	hurl --test $(HURL_VARS) \
+		--variable student_id=student_$$(date +%s)17 \
+		tests/ui/submit-collapses-pending.hurl
 
 # Build, start server with a temp DB, run Hurl tests, stop server.
 # Usage: make test-hurl-ci [TEST_PORT=18080] [TEACHER_ID=123]

--- a/src/storage/lesson.go
+++ b/src/storage/lesson.go
@@ -257,6 +257,7 @@ func (d *DB) ListLessonPreviousTaskRecords(lesson *Lesson) ([]*TaskRecord, error
 			if err != nil {
 				return err
 			}
+			taskRecord.Status = enrolledTask.Status
 			result = append(result, taskRecord)
 		}
 		return nil

--- a/src/storage/task.go
+++ b/src/storage/task.go
@@ -241,7 +241,7 @@ func (d *DB) RegisterToLesson(lessonID LessonID, taskID TaskID, authorID UserID,
 		if err != nil {
 			return err
 		}
-		if lastTaskRecord.Status != SubmitTaskRecord && lastTaskRecord.Status != RevokedTaskRecord {			
+		if lastTaskRecord.Status != SubmitTaskRecord && lastTaskRecord.Status != RevokedTaskRecord {
 			return fmt.Errorf("unexpected task state for registration on lesson: %s", lastTaskRecord.Status)
 		}
 		lastTaskRecord.Status = RegisterTaskRecord
@@ -289,10 +289,7 @@ func (d *DB) UnregisterAllFromLesson(lessonID LessonID) (int, error) {
 			if err != nil {
 				return err
 			}
-			taskRecord.Status = SubmitTaskRecord   
-			taskRecord.LessonID = ""   
-			taskRecord.LessonAt = time.Time{}   
-			taskRecord.RegisteredAt = time.Time{}
+			taskRecord.Status = SubmitTaskRecord
 			if err := setValue(b, taskRecord.ID, *taskRecord); err != nil {
 				return err
 			}
@@ -338,11 +335,8 @@ func (d *DB) UnregisterFromLesson(lessonID LessonID, taskID TaskID, authorID Use
 		if taskRecord.Status != RegisterTaskRecord {
 			return fmt.Errorf("task record is not in register state")
 		}
-		
-		taskRecord.Status = SubmitTaskRecord  
-		taskRecord.LessonID = ""  
-		taskRecord.LessonAt = time.Time{}  
-		taskRecord.RegisteredAt = time.Time{}
+
+		taskRecord.Status = SubmitTaskRecord
 		if err := setValue(b, taskRecord.ID, *taskRecord); err != nil {
 			return err
 		}

--- a/src/storage/task.go
+++ b/src/storage/task.go
@@ -97,6 +97,11 @@ func (d *DB) AddTaskRecord(record *TaskRecord) error {
 						}
 					}
 				}
+			} else if existingRecord.Status == SubmitTaskRecord {
+				existingRecord.Status = RevokedTaskRecord
+				if err := setValue(b, key, existingRecord); err != nil {
+					return err
+				}
 			}
 
 		}
@@ -236,7 +241,7 @@ func (d *DB) RegisterToLesson(lessonID LessonID, taskID TaskID, authorID UserID,
 		if err != nil {
 			return err
 		}
-		if lastTaskRecord.Status != SubmitTaskRecord {
+		if lastTaskRecord.Status != SubmitTaskRecord && lastTaskRecord.Status != RevokedTaskRecord {			
 			return fmt.Errorf("unexpected task state for registration on lesson: %s", lastTaskRecord.Status)
 		}
 		lastTaskRecord.Status = RegisterTaskRecord
@@ -284,7 +289,10 @@ func (d *DB) UnregisterAllFromLesson(lessonID LessonID) (int, error) {
 			if err != nil {
 				return err
 			}
-			taskRecord.Status = RevokedTaskRecord
+			taskRecord.Status = SubmitTaskRecord   
+			taskRecord.LessonID = ""   
+			taskRecord.LessonAt = time.Time{}   
+			taskRecord.RegisteredAt = time.Time{}
 			if err := setValue(b, taskRecord.ID, *taskRecord); err != nil {
 				return err
 			}
@@ -330,8 +338,11 @@ func (d *DB) UnregisterFromLesson(lessonID LessonID, taskID TaskID, authorID Use
 		if taskRecord.Status != RegisterTaskRecord {
 			return fmt.Errorf("task record is not in register state")
 		}
-
-		taskRecord.Status = RevokedTaskRecord
+		
+		taskRecord.Status = SubmitTaskRecord  
+		taskRecord.LessonID = ""  
+		taskRecord.LessonAt = time.Time{}  
+		taskRecord.RegisteredAt = time.Time{}
 		if err := setValue(b, taskRecord.ID, *taskRecord); err != nil {
 			return err
 		}

--- a/tests/run-hurl.sh
+++ b/tests/run-hurl.sh
@@ -102,6 +102,12 @@ run_test tests/ui/lesson-student-queue-visibility.hurl \
 
 run_test tests/ui/lesson-preview-unauthenticated.hurl
 
+run_test tests/ui/reregistration-after-revoke.hurl \
+    --variable "student_id=${TIMESTAMP}16"
+
+run_test tests/ui/submit-collapses-pending.hurl \
+    --variable "student_id=${TIMESTAMP}17"
+
 # Stop server
 kill "$SERVER_PID" 2>/dev/null
 rm -f "$TEST_DB"

--- a/tests/ui/reregistration-after-revoke.hurl
+++ b/tests/ui/reregistration-after-revoke.hurl
@@ -1,0 +1,133 @@
+# Re-registration after revoke Test
+# Covers three scenarios:
+# 1. Task page shows Pending (not Dropped) after revoke
+# 2. Teacher's lesson page shows Dropped status in history after revoke by a student
+# 3. Student can re-register the same task to a different lesson after revoke
+#
+# Prerequisites: server running against a fresh DB with default config
+#   (teacher_ids: ["123"]).
+# Run: hurl --test \
+#   --variable student_id=$(date +%s) \
+#   --variable teacher_id=123 \
+#   tests/ui/reregistration-after-revoke.hurl
+
+# Step 1: Sign in as teacher
+POST {{base_url}}/signin
+[Options]
+variable: teacher_password=TeacherPass123!
+variable: student_password=StudentPass123!
+variable: student_username=Re-registrated Student
+variable: task_id=task1
+[FormParams]
+id: {{teacher_id}}
+password: {{teacher_password}}
+
+HTTP 303
+[Captures]
+teacher_token: cookie "user_data"
+
+
+
+# Step 2: Teacher creates lesson A
+POST {{base_url}}/api/lessons
+Cookie: user_data={{teacher_token}}
+[Options]
+location: true
+[FormParams]
+date: 2099-12-31
+time: 10:00
+description: Lesson A revoke test
+
+HTTP 200
+[Captures]
+lesson_a_id: url regex "/lesson/([^/?#]+)"
+
+# Step 3: Teacher creates lesson B
+POST {{base_url}}/api/lessons
+Cookie: user_data={{teacher_token}}
+[Options]
+location: true
+[FormParams]
+date: 2099-12-31
+time: 12:00
+description: Lesson B revoke test
+
+HTTP 200
+[Captures]
+lesson_b_id: url regex "/lesson/([^/?#]+)"
+
+GET {{base_url}}/logout
+HTTP 303
+
+# Step 4: Sign up student
+POST {{base_url}}/signup
+[FormParams]
+id: {{student_id}}
+password: {{student_password}}
+username: {{student_username}}
+
+HTTP 303
+[Captures]
+student_token: cookie "user_data"
+
+GET {{base_url}}/logout
+HTTP 303
+
+# Step 5: Student submits task
+POST {{base_url}}/user/{{student_id}}/task/{{task_id}}/journal
+Cookie: user_data={{student_token}}
+[FormParams]
+content: Submission for revoke test
+
+HTTP 303
+
+# Step 6: Student registers task to lesson A
+POST {{base_url}}/api/lesson/{{lesson_a_id}}/register
+Cookie: user_data={{student_token}}
+[FormParams]
+taskRecordID: {{task_id}}
+studentID: {{student_id}}
+
+HTTP 200
+
+# Step 7: Student revokes from lesson A
+POST {{base_url}}/api/lesson/{{lesson_a_id}}/unregister
+Cookie: user_data={{student_token}}
+[FormParams]
+taskID: {{task_id}}
+
+HTTP 303
+
+# Scenario 1: task page shows Pending, not Dropped
+GET {{base_url}}/user/{{student_id}}/task/{{task_id}}
+Cookie: user_data={{student_token}}
+
+HTTP 200
+[Asserts]
+body contains "Pending"
+body not contains "Dropped"
+
+# Scenario 2: teacher's lesson A page shows Dropped in history
+GET {{base_url}}/lesson/{{lesson_a_id}}?showRevoked=true
+Cookie: user_data={{teacher_token}}
+
+HTTP 200
+[Asserts]
+body contains "Dropped"
+
+# Scenario 3: student re-registers same task to lesson B
+POST {{base_url}}/api/lesson/{{lesson_b_id}}/register
+Cookie: user_data={{student_token}}
+[FormParams]
+taskRecordID: {{task_id}}
+studentID: {{student_id}}
+
+HTTP 200
+
+# Verify task is now Queued for lesson B
+GET {{base_url}}/user/{{student_id}}/task/{{task_id}}
+Cookie: user_data={{student_token}}
+
+HTTP 200
+[Asserts]
+body contains "Queued"

--- a/tests/ui/submit-collapses-pending.hurl
+++ b/tests/ui/submit-collapses-pending.hurl
@@ -1,0 +1,67 @@
+# Submit Collapses Pending Test
+# Verifies that the older pending record is collapsed to Dropped 
+# when a student adds a new submission while an older one is pending. After the second
+# submission the task page must show only one Pending record (the new one)
+# and at least one Dropped (the old one).
+#
+# Prerequisites: server running against a fresh DB with default config
+#   (teacher_ids: ["123"]).
+# Run: hurl --test \
+#   --variable student_id=$(date +%s) \
+#   --variable teacher_id=123 \
+#   tests/ui/submit-collapses-pending.hurl
+
+# Step 1: Sign in as teacher
+POST {{base_url}}/signin
+[Options]
+variable: teacher_password=TeacherPass123!
+variable: student_password=StudentPass123!
+variable: student_username=CollapseStudent
+variable: task_id=task1
+[FormParams]
+id: {{teacher_id}}
+password: {{teacher_password}}
+
+HTTP 303
+
+GET {{base_url}}/logout
+HTTP 303
+
+# Step 2: Sign up student
+POST {{base_url}}/signup
+[FormParams]
+id: {{student_id}}
+password: {{student_password}}
+username: {{student_username}}
+
+HTTP 303
+[Captures]
+student_token: cookie "user_data"
+
+GET {{base_url}}/logout
+HTTP 303
+
+# Step 3: Student submits first version
+POST {{base_url}}/user/{{student_id}}/task/{{task_id}}/journal
+Cookie: user_data={{student_token}}
+[FormParams]
+content: First pending submission
+
+HTTP 303
+
+# Step 4: Student submits second version (first must get Dropped status)
+POST {{base_url}}/user/{{student_id}}/task/{{task_id}}/journal
+Cookie: user_data={{student_token}}
+[FormParams]
+content: Second submission
+
+HTTP 303
+
+# Task page shows new submission as Pending and the old one as Dropped
+GET {{base_url}}/user/{{student_id}}/task/{{task_id}}
+Cookie: user_data={{student_token}}
+
+HTTP 200
+[Asserts]
+body contains "Pending"
+body contains "Dropped"


### PR DESCRIPTION
There is one problem that's contradicted with GUIDE.md and with the idea of submit-ord:
In guide it is said that if a person wants to reschedule a registration for another class - he should choose "revoke" in the section "// register", so task record gets pending status. But it doesn't work like that in prod. Now task record gets dropped status on revoke action. So a person has to resubmit his task, and he will be again on the end of the list.

And there is another (just a visual) problem: if a person wants to add another task record when there's already pending task record, the status of the existing record remains pending (I attached a photo of that). I think it's better to give it dropped status.
<img width="1299" height="326" alt="pending problem" src="https://github.com/user-attachments/assets/e0e795cf-0502-4f3c-8140-67ea82eb4def" />


