### PR TITLE
fix: Skip images and raw html when rendering markdown to prevent CSRF

### DIFF
--- a/src/util/markdown.go
+++ b/src/util/markdown.go
@@ -22,7 +22,7 @@ func RenderMarkdown(input string) template.HTML {
 	doc := p.Parse([]byte(input))
 
 	opts := html.RendererOptions{
-		Flags:          html.CommonFlags,
+		Flags:          html.CommonFlags | html.SkipImages | html.SkipHTML,
 		RenderNodeHook: nil,
 	}
 	renderer := html.NewRenderer(opts)

--- a/src/util/markdown_test.go
+++ b/src/util/markdown_test.go
@@ -27,3 +27,17 @@ func TestRenderMarkdown_RelativeLinkStaysInSameTab(t *testing.T) {
 		t.Errorf("did not expect target=\"_blank\" on relative link, got: %s", got)
 	}
 }
+
+func TestRenderMarkdown_ImagesAreStripped(t *testing.T) {
+	got := string(RenderMarkdown("see my cool image ![cool image](/logout)"))
+	if strings.Contains(got, `src="/logout"`) {
+		t.Fatalf("expected image removed, got: %s", got)
+	}
+}
+
+func TestRenderMarkdown_HtmlImagesAreStripped(t *testing.T) {
+	got := string(RenderMarkdown("see my cool image <img alt=\"cool image\" src=\"/logout\"</img>"))
+	if strings.Contains(got, `src="/logout"`) {
+		t.Fatalf("expected image removed, got: %s", got)
+	}
+}


### PR DESCRIPTION
Bluemonday's UGCPolicy strips every autoloading tag, except img. This allowed malicious actor to insert unwanted image sources like:
- `/logout` - to perform the logout of the one who sees the rendered page
- `/set-cookie?token=XXX` - to perform the reverse session fixation attack

To forbid images from reaching final HTML two flags were added to html.RendererOptions:
- `html.SkipImages` forbids Markdown images
- `html.SkipHTML` forbids user HTML inserted into Markdown document (such as `<img>` tag)

Two new tests were introduced to test the fix.