### PR TITLE
fix: Split `Save` into `Create` and `Update` user to prevent TOCTOU race

### DIFF
--- a/src/handlers/auth.go
+++ b/src/handlers/auth.go
@@ -144,9 +144,9 @@ func SignupHandler(w http.ResponseWriter, r *http.Request) {
 		UserGroup:    "student",
 	}
 
-	if err := DB.SaveUser(userData); err != nil {
-		renderAuthPageWithError(w, "Error creating user")
-		log.Printf("Error saving user: %v", err)
+	if err := DB.CreateUser(userData); err != nil {
+		renderAuthPageWithError(w, "User already exists")
+		log.Printf("Error creating user: %v", err)
 		return
 	}
 

--- a/src/storage/db_test.go
+++ b/src/storage/db_test.go
@@ -40,9 +40,9 @@ func TestSaveAndGetUser(t *testing.T) {
 		Username: "testuser",
 	}
 
-	err := db.SaveUser(user)
+	err := db.CreateUser(user)
 	if err != nil {
-		t.Fatalf("Failed to save user: %v", err)
+		t.Fatalf("Failed to create user: %v", err)
 	}
 
 	retrieved, err := db.GetUser("123")
@@ -95,10 +95,10 @@ func TestEmptyIDValidation(t *testing.T) {
 	db, tempDir := setupTestDB(t)
 	defer cleanupTestDB(db, tempDir)
 
-	// Test saving with empty ID
-	err := db.SaveUser(&UserData{Username: "noID"})
+	// Test creating with empty ID
+	err := db.CreateUser(&UserData{Username: "noID"})
 	if err == nil {
-		t.Error("Expected error when saving user with empty ID")
+		t.Error("Expected error when creating user with empty ID")
 	}
 
 	// Test updating an existing user's username
@@ -106,9 +106,9 @@ func TestEmptyIDValidation(t *testing.T) {
 		ID:       "update_test",
 		Username: "original_name",
 	}
-	err = db.SaveUser(user)
+	err = db.CreateUser(user)
 	if err != nil {
-		t.Fatalf("Failed to save initial user: %v", err)
+		t.Fatalf("Failed to create initial user: %v", err)
 	}
 
 	// Update username
@@ -116,7 +116,7 @@ func TestEmptyIDValidation(t *testing.T) {
 		ID:       "update_test",
 		Username: "updated_name",
 	}
-	err = db.SaveUser(updatedUser)
+	err = db.UpdateUser(updatedUser)
 	if err != nil {
 		t.Fatalf("Failed to update user: %v", err)
 	}
@@ -142,7 +142,7 @@ func TestUserRoleFlags(t *testing.T) {
 	db, tempDir := setupTestDB(t)
 	defer cleanupTestDB(db, tempDir)
 
-	// Test saving user with role flags
+	// Test creating user with role flags
 	user := &UserData{
 		ID:        "teacher1",
 		Username:  "teacheruser",
@@ -150,9 +150,9 @@ func TestUserRoleFlags(t *testing.T) {
 		IsTeacher: true,
 	}
 
-	err := db.SaveUser(user)
+	err := db.CreateUser(user)
 	if err != nil {
-		t.Fatalf("Failed to save user: %v", err)
+		t.Fatalf("Failed to create user: %v", err)
 	}
 
 	// Retrieve and verify
@@ -170,7 +170,7 @@ func TestUserRoleFlags(t *testing.T) {
 
 	// Test updating role flags
 	user.IsStudent = true
-	err = db.SaveUser(user)
+	err = db.UpdateUser(user)
 	if err != nil {
 		t.Fatalf("Failed to update user: %v", err)
 	}

--- a/src/storage/flow_test.go
+++ b/src/storage/flow_test.go
@@ -12,9 +12,9 @@ func setupLessonFlowDB(t *testing.T) (*DB, string, *UserData, *UserData, TaskID,
 	db, tempDir := setupTestDB(t)
 
 	teacher := &UserData{ID: "teacher", Username: "Teacher", IsTeacher: true}
-	assert.NoError(t, db.SaveUser(teacher))
+	assert.NoError(t, db.CreateUser(teacher))
 	student := &UserData{ID: "student", Username: "Student", IsStudent: true}
-	assert.NoError(t, db.SaveUser(student))
+	assert.NoError(t, db.CreateUser(student))
 
 	lesson := &Lesson{
 		DateTime:    time.Now().Add(24 * time.Hour),
@@ -152,7 +152,7 @@ func TestLessonFlow(t *testing.T) {
 		IsTeacher: true,
 		IsStudent: false,
 	}
-	assert.NoError(t, db.SaveUser(teacher))
+	assert.NoError(t, db.CreateUser(teacher))
 
 	student := &UserData{
 		ID:        studentID,
@@ -160,7 +160,7 @@ func TestLessonFlow(t *testing.T) {
 		IsTeacher: false,
 		IsStudent: true,
 	}
-	assert.NoError(t, db.SaveUser(student))
+	assert.NoError(t, db.CreateUser(student))
 
 	// Create lesson
 	lesson := &Lesson{

--- a/src/storage/user.go
+++ b/src/storage/user.go
@@ -24,7 +24,7 @@ type UserData struct {
 	ResetTokenExp time.Time               `json:"reset_token_exp,omitempty"`
 }
 
-func (d *DB) SaveUser(userData *UserData) error {
+func (d *DB) CreateUser(userData *UserData) error {
 	if userData.ID == "" {
 		return fmt.Errorf("user ID cannot be empty")
 	}
@@ -32,79 +32,20 @@ func (d *DB) SaveUser(userData *UserData) error {
 	return d.db.Update(func(tx *bolt.Tx) error {
 		b := tx.Bucket(d.bucketName)
 
-		// Check if user exists
 		existingData := b.Get([]byte(userData.ID))
 		if existingData != nil {
-			// User exists, only update username if needed
-			var existingUser UserData
-			if err := json.Unmarshal(existingData, &existingUser); err != nil {
-				return fmt.Errorf("could not unmarshal existing user data: %w", err)
-			}
-
-			// Update username if different
-			changed := false
-			if existingUser.Username != userData.Username {
-				existingUser.Username = userData.Username
-				changed = true
-			}
-
-			// Update role flags if different
-			if existingUser.IsStudent != userData.IsStudent {
-				existingUser.IsStudent = userData.IsStudent
-				changed = true
-			}
-			if existingUser.IsTeacher != userData.IsTeacher {
-				existingUser.IsTeacher = userData.IsTeacher
-				changed = true
-			}
-
-			if existingUser.UserGroup != userData.UserGroup && userData.UserGroup != "" {
-				existingUser.UserGroup = userData.UserGroup
-				changed = true
-			}
-
-			if len(userData.PasswordHash) > 0 {
-				existingUser.PasswordHash = userData.PasswordHash
-				changed = true
-			}
-
-			// Preserve existing journals if not updating them
-			if len(userData.Journals) > 0 {
-				existingUser.Journals = userData.Journals
-				changed = true
-			}
-
-			// Preserve existing lesson IDs if not updating them
-			if len(userData.LessonIDs) > 0 {
-				existingUser.LessonIDs = userData.LessonIDs
-				changed = true
-			}
-
-			// If nothing changed, return early
-			if !changed {
-				return nil
-			}
-
-			buf, err := json.Marshal(existingUser)
-			if err != nil {
-				return fmt.Errorf("could not marshal user data: %w", err)
-			}
-
-			return b.Put([]byte(userData.ID), buf)
+			return fmt.Errorf("user already exists")
 		}
 
-		// New user, set creation time
 		now := time.Now()
 		if userData.CreatedAt.IsZero() {
 			userData.CreatedAt = now
 		}
 
-		// Initialize journals if nil
 		if userData.Journals == nil {
 			userData.Journals = make(map[TaskID][]TaskRecord)
 		}
 
-		// Initialize lesson IDs if nil
 		if userData.LessonIDs == nil {
 			userData.LessonIDs = []LessonID{}
 		}
@@ -122,6 +63,71 @@ func (d *DB) SaveUser(userData *UserData) error {
 	})
 }
 
+func (d *DB) UpdateUser(userData *UserData) error {
+	if userData.ID == "" {
+		return fmt.Errorf("user ID cannot be empty")
+	}
+
+	return d.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(d.bucketName)
+
+		existingData := b.Get([]byte(userData.ID))
+		if existingData == nil {
+			return fmt.Errorf("user not found")
+		}
+
+		var existingUser UserData
+		if err := json.Unmarshal(existingData, &existingUser); err != nil {
+			return fmt.Errorf("could not unmarshal existing user data: %w", err)
+		}
+
+		changed := false
+		if existingUser.Username != userData.Username {
+			existingUser.Username = userData.Username
+			changed = true
+		}
+
+		if existingUser.IsStudent != userData.IsStudent {
+			existingUser.IsStudent = userData.IsStudent
+			changed = true
+		}
+		if existingUser.IsTeacher != userData.IsTeacher {
+			existingUser.IsTeacher = userData.IsTeacher
+			changed = true
+		}
+
+		if existingUser.UserGroup != userData.UserGroup && userData.UserGroup != "" {
+			existingUser.UserGroup = userData.UserGroup
+			changed = true
+		}
+
+		if len(userData.PasswordHash) > 0 {
+			existingUser.PasswordHash = userData.PasswordHash
+			changed = true
+		}
+
+		if len(userData.Journals) > 0 {
+			existingUser.Journals = userData.Journals
+			changed = true
+		}
+
+		if len(userData.LessonIDs) > 0 {
+			existingUser.LessonIDs = userData.LessonIDs
+			changed = true
+		}
+
+		if !changed {
+			return nil
+		}
+
+		buf, err := json.Marshal(existingUser)
+		if err != nil {
+			return fmt.Errorf("could not marshal user data: %w", err)
+		}
+
+		return b.Put([]byte(userData.ID), buf)
+	})
+}
 func (d *DB) ListUsers() ([]*UserData, error) {
 	var users []*UserData
 	err := d.db.View(func(tx *bolt.Tx) error {


### PR DESCRIPTION
Previous user creation flow:
- Check if user exists
- Password Hashing (~250ms, attack possible if another signup reached in these ~250ms)
- Create user (and attacker's request would overwrite it, instead of failing)

New user creation flow:
- Check if user exists
- Password hashing
- User creation (and early-exiting if exists, which prevents race)
- User modification