### PR TITLE
feat: score-rules debug endpoint

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,6 +76,9 @@ test-hurl:
 	hurl --test $(HURL_VARS) \
 		--variable student_id=student_$$(date +%s)21 \
 		tests/ui/teacher-note.hurl
+	hurl --test $(HURL_VARS) \
+		--variable student_id=student_$$(date +%s)22 \
+		tests/ui/score-rules-debug.hurl
 
 # Build, start server with a temp DB, run Hurl tests, stop server.
 # Usage: make test-hurl-ci [TEST_PORT=18080] [TEACHER_ID=123]

--- a/main.go
+++ b/main.go
@@ -224,6 +224,7 @@ func main() {
 	r.HandleFunc("/users/csv", handlers.UserListCSVHandler).Methods("GET")
 	r.HandleFunc("/teachers", handlers.TeacherListHandler).Methods("GET")
 	r.HandleFunc("/user/{userID}", handlers.UserInfoHandler).Methods("GET")
+	r.HandleFunc("/user/{userID}/score-debug", handlers.ScoreRulesDebugHandler).Methods("GET")
 	r.HandleFunc("/user/{userID}/task/{taskID}", handlers.TaskDetailHandler).Methods("GET")
 	r.HandleFunc("/user/{userID}/task/{taskID}/journal", handlers.AddTaskRecordHandler).Methods("POST")
 	r.HandleFunc("/user/{userID}/note", handlers.AddUserNoteHandler).Methods("POST")

--- a/src/handlers/scorerule.go
+++ b/src/handlers/scorerule.go
@@ -8,11 +8,61 @@ import (
 	"github.com/ryukzak/slap/src/storage"
 )
 
+// taskStatusLabel maps a stored record status to the label shown in the UI.
+func taskStatusLabel(s storage.TaskRecordStatus) string {
+	switch s {
+	case storage.SubmitTaskRecord:
+		return "Pending"
+	case storage.RegisterTaskRecord:
+		return "Queued"
+	case storage.RevokedTaskRecord:
+		return "Dropped"
+	case storage.ReviewTaskRecord:
+		return "Feedback"
+	case storage.ReviewedTaskRecord:
+		return "Checked"
+	default:
+		return string(s)
+	}
+}
+
 type Evaluation struct {
 	Rule        config.ScoreRule
 	Applies     bool
 	IsActive    bool
 	CountBefore int
+	// Debug captures the per-task and per-rule details of this evaluation so
+	// the score-rules debug endpoint can show why a rule did or did not apply.
+	// It is populated on the real evaluation path, so it always reflects the
+	// actual behaviour rather than a re-implementation.
+	Debug EvaluationDebug
+}
+
+// TaskCheckDebug records, for one task referenced by a rule, the timestamp the
+// evaluator compared against the rule's deadline and whether that task passed
+// the rule's per-task predicate.
+type TaskCheckDebug struct {
+	TaskID    string     `json:"task_id"`
+	CheckedAt *time.Time `json:"checked_at"`      // nil = task was never accepted (Checked)
+	State     string     `json:"state,omitempty"` // record state the checked time came from (or why none)
+	Pass      bool       `json:"pass"`            // satisfies this condition's per-task predicate
+}
+
+// EvaluationDebug is a self-describing trace of a single rule evaluation.
+type EvaluationDebug struct {
+	Rule          string           `json:"rule"`
+	ConditionKind string           `json:"condition_kind"` // min_checked_before | after | before | interval | none
+	Now           time.Time        `json:"now"`
+	CheckedAfter  *time.Time       `json:"checked_after,omitempty"`
+	CheckedBefore *time.Time       `json:"checked_before,omitempty"`
+	MinRequired   int              `json:"min_required,omitempty"`
+	Tasks         []TaskCheckDebug `json:"tasks"`
+	Count         int              `json:"count"` // number of tasks that passed the per-task predicate
+	IsActive      bool             `json:"is_active"`
+	Applies       bool             `json:"applies"`
+	Status        string           `json:"status"`
+	Effect        int              `json:"effect"`         // the rule's configured effect
+	AppliedEffect int              `json:"applied_effect"` // effect actually contributed (0 unless Applies)
 }
 
 type Evaluator struct {
@@ -23,80 +73,112 @@ func NewEvaluator(cfg *config.Config) *Evaluator {
 	return &Evaluator{config: cfg}
 }
 
-// EvaluateForStudent evaluates a rule at a specific point in time
+// EvaluateForStudent evaluates a rule at a specific point in time.
+//
+// The branch order below is significant and preserved as-is: a rule with both
+// checked_after and checked_before but no min is handled by the "before" branch,
+// so the "interval" branch is only reachable in theory. The debug trace reports
+// whichever branch actually ran, so it stays faithful to real behaviour.
 func (e *Evaluator) EvaluateForStudent(rule config.ScoreRule, now time.Time, getCheckedTime func(taskID storage.TaskID) (*time.Time, error)) (Evaluation, error) {
 	eval := Evaluation{
 		Rule:    rule,
 		Applies: false,
 	}
+	dbg := EvaluationDebug{
+		Rule:          rule.Name,
+		Now:           now,
+		CheckedAfter:  rule.Condition.CheckedAfter,
+		CheckedBefore: rule.Condition.CheckedBefore,
+		MinRequired:   rule.Condition.MinCheckedBefore,
+		Effect:        rule.Effect,
+	}
 
-	// Collect checked times
-	checkedTimes := make(map[storage.TaskID]*time.Time)
+	// Collect checked times in rule order so the debug trace is stable.
+	tasks := make([]TaskCheckDebug, 0, len(rule.TaskIDs))
 	for _, taskID := range rule.TaskIDs {
 		t, err := getCheckedTime(taskID)
 		if err != nil {
 			return Evaluation{}, fmt.Errorf("failed to get checked time for task %s: %w", taskID, err)
 		}
-		checkedTimes[taskID] = t
+		tasks = append(tasks, TaskCheckDebug{TaskID: taskID, CheckedAt: t})
 	}
 
+	switch {
 	// Min checked before
-	if rule.Condition.MinCheckedBefore > 0 {
+	case rule.Condition.MinCheckedBefore > 0:
+		dbg.ConditionKind = "min_checked_before"
 		countBefore := 0
-		for _, t := range checkedTimes {
-			if t != nil && t.Before(*rule.Condition.CheckedBefore) {
+		for i := range tasks {
+			pass := tasks[i].CheckedAt != nil && tasks[i].CheckedAt.Before(*rule.Condition.CheckedBefore)
+			tasks[i].Pass = pass
+			if pass {
 				countBefore++
 			}
 		}
 		eval.CountBefore = countBefore
 
-		if countBefore >= rule.Condition.MinCheckedBefore {
-			return eval, nil
+		if countBefore < rule.Condition.MinCheckedBefore {
+			eval.IsActive = !now.After(*rule.Condition.CheckedBefore)
+			eval.Applies = !eval.IsActive
 		}
 
-		eval.IsActive = !now.After(*rule.Condition.CheckedBefore)
-		eval.Applies = !eval.IsActive
-		return eval, nil
-	}
-
 	// After
-	if rule.Condition.CheckedAfter != nil && rule.Condition.CheckedBefore == nil {
+	case rule.Condition.CheckedAfter != nil && rule.Condition.CheckedBefore == nil:
+		dbg.ConditionKind = "after"
 		allCheckedBefore := true
-		for _, t := range checkedTimes {
-			if t == nil || !t.Before(*rule.Condition.CheckedAfter) {
+		for i := range tasks {
+			onTime := tasks[i].CheckedAt != nil && tasks[i].CheckedAt.Before(*rule.Condition.CheckedAfter)
+			tasks[i].Pass = onTime
+			if !onTime {
 				allCheckedBefore = false
-				break
 			}
 		}
 		eval.IsActive = !now.After(*rule.Condition.CheckedAfter)
 		eval.Applies = !eval.IsActive && !allCheckedBefore
-		return eval, nil
-	}
 
 	// Before
-	if rule.Condition.CheckedBefore != nil && rule.Condition.MinCheckedBefore == 0 {
+	case rule.Condition.CheckedBefore != nil && rule.Condition.MinCheckedBefore == 0:
+		dbg.ConditionKind = "before"
 		hasCheckedBefore := false
-		for _, t := range checkedTimes {
-			if t != nil && t.Before(*rule.Condition.CheckedBefore) {
+		for i := range tasks {
+			pass := tasks[i].CheckedAt != nil && tasks[i].CheckedAt.Before(*rule.Condition.CheckedBefore)
+			tasks[i].Pass = pass
+			if pass {
 				hasCheckedBefore = true
-				break
 			}
 		}
 		eval.IsActive = !now.After(*rule.Condition.CheckedBefore)
 		eval.Applies = hasCheckedBefore
-		return eval, nil
-	}
 
 	// Interval
-	if rule.Condition.CheckedAfter != nil && rule.Condition.CheckedBefore != nil {
-		for _, t := range checkedTimes {
-			if t != nil && t.After(*rule.Condition.CheckedAfter) && t.Before(*rule.Condition.CheckedBefore) {
+	case rule.Condition.CheckedAfter != nil && rule.Condition.CheckedBefore != nil:
+		dbg.ConditionKind = "interval"
+		for i := range tasks {
+			t := tasks[i].CheckedAt
+			pass := t != nil && t.After(*rule.Condition.CheckedAfter) && t.Before(*rule.Condition.CheckedBefore)
+			tasks[i].Pass = pass
+			if pass {
 				eval.Applies = true
-				return eval, nil
 			}
 		}
-		return eval, nil
+
+	default:
+		dbg.ConditionKind = "none"
 	}
+
+	for _, tc := range tasks {
+		if tc.Pass {
+			dbg.Count++
+		}
+	}
+	dbg.Tasks = tasks
+	dbg.IsActive = eval.IsActive
+	dbg.Applies = eval.Applies
+	dbg.Status = eval.Status()
+	if eval.Applies {
+		dbg.AppliedEffect = rule.Effect
+	}
+	eval.Debug = dbg
 
 	return eval, nil
 }

--- a/src/handlers/scorerule_debug.go
+++ b/src/handlers/scorerule_debug.go
@@ -1,0 +1,201 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/gorilla/mux"
+	"github.com/ryukzak/slap/src/storage"
+)
+
+// ScoreRulesDebugResponse is the full machine-readable trace returned by the
+// score-rules debug endpoint.
+type ScoreRulesDebugResponse struct {
+	UserID      string            `json:"user_id"`
+	Username    string            `json:"username"`
+	Now         time.Time         `json:"now"`
+	Timezone    string            `json:"timezone"`
+	TotalEffect int               `json:"total_effect"`
+	Rules       []EvaluationDebug `json:"rules"`
+}
+
+// ScoreRulesDebugHandler exposes the per-task, per-rule reasoning behind a
+// student's score-rule evaluation so the actual checked time, the expected
+// deadline, the pass/fail of every task, the counted number and the rule result
+// can be inspected. It returns JSON by default, or plain text with ?format=text.
+//
+// Access mirrors the profile page: a student may inspect only their own
+// evaluation; teachers may inspect anyone.
+func ScoreRulesDebugHandler(w http.ResponseWriter, r *http.Request) {
+	sessionUser := userSession(w, r)
+	if sessionUser == nil {
+		return
+	}
+
+	profileUserID := mux.Vars(r)["userID"]
+	if profileUserID == "" {
+		http.Error(w, "User ID is required", http.StatusBadRequest)
+		return
+	}
+	if profileUserID != sessionUser.ID && !sessionUser.IsTeacher {
+		http.Error(w, "Forbidden", http.StatusForbidden)
+		return
+	}
+
+	dbUser, err := DB.GetUser(profileUserID)
+	if err != nil || dbUser == nil {
+		http.Error(w, "User not found", http.StatusNotFound)
+		return
+	}
+
+	// Same checked-time source as the profile page (src/handlers/user.go): the
+	// CreatedAt of the newest accepted (Checked) record. The state label (and
+	// read) is cached so each task is loaded only once.
+	stateCache := map[storage.TaskID]string{}
+	getCheckedTime := func(taskID storage.TaskID) (*time.Time, error) {
+		records, err := DB.ListTaskRecords(profileUserID, taskID)
+		if err != nil {
+			return nil, err
+		}
+		at, state := debugCheckedInfo(records)
+		stateCache[taskID] = state
+		return at, nil
+	}
+
+	evaluator := NewEvaluator(AppConfig)
+	now := time.Now()
+
+	resp := ScoreRulesDebugResponse{
+		UserID:   dbUser.ID,
+		Username: dbUser.Username,
+		Now:      now,
+		Timezone: PrimaryTZName,
+	}
+
+	for _, rule := range AppConfig.ScoreRules {
+		eval, err := evaluator.EvaluateForStudent(rule, now, getCheckedTime)
+		if err != nil {
+			log.Printf("Error evaluating rule %s for user %s: %v", rule.Name, profileUserID, err)
+			http.Error(w, "Failed to evaluate score rules", http.StatusInternalServerError)
+			return
+		}
+		for i := range eval.Debug.Tasks {
+			eval.Debug.Tasks[i].State = stateCache[eval.Debug.Tasks[i].TaskID]
+		}
+		resp.Rules = append(resp.Rules, eval.Debug)
+		resp.TotalEffect += eval.Debug.AppliedEffect
+	}
+
+	if r.URL.Query().Get("format") == "text" {
+		w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+		if _, err := io.WriteString(w, renderScoreDebugText(resp)); err != nil {
+			log.Printf("Error writing score debug text for user %s: %v", profileUserID, err)
+		}
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(resp); err != nil {
+		log.Printf("Error encoding score debug for user %s: %v", profileUserID, err)
+	}
+}
+
+// debugCheckedInfo returns the checked time (CreatedAt of the newest accepted
+// record, matching the profile page) plus a label describing the record state
+// it came from, or why none exists. records must be newest-first.
+func debugCheckedInfo(records []storage.TaskRecord) (*time.Time, string) {
+	if len(records) == 0 {
+		return nil, "not submitted"
+	}
+	for i := range records {
+		if records[i].Status == storage.ReviewedTaskRecord {
+			return &records[i].CreatedAt, "Checked"
+		}
+	}
+	return nil, "not checked (" + taskStatusLabel(records[0].Status) + ")"
+}
+
+// fmtDebugTime renders a timestamp in the primary timezone, or "<never>" for a
+// task that was never accepted.
+func fmtDebugTime(t *time.Time) string {
+	if t == nil {
+		return "<never accepted>"
+	}
+	loc := PrimaryLoc
+	if loc == nil {
+		loc = time.UTC
+	}
+	return t.In(loc).Format("2006-01-02 15:04:05 MST")
+}
+
+func renderScoreDebugText(resp ScoreRulesDebugResponse) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "score-rule debug for @%s (id %s)\n", resp.Username, resp.UserID)
+	fmt.Fprintf(&b, "now: %s  (timezone: %s)\n", fmtDebugTime(&resp.Now), resp.Timezone)
+	fmt.Fprintf(&b, "checked time = submission time (CreatedAt) of the newest accepted (Checked) record\n")
+	b.WriteString(strings.Repeat("=", 72) + "\n\n")
+
+	for _, rule := range resp.Rules {
+		fmt.Fprintf(&b, "Rule: %s  [effect %+d]\n", rule.Rule, rule.Effect)
+		fmt.Fprintf(&b, "  condition: %s", rule.ConditionKind)
+		if rule.MinRequired > 0 {
+			fmt.Fprintf(&b, "  (min required: %d)", rule.MinRequired)
+		}
+		b.WriteString("\n")
+		if rule.CheckedAfter != nil {
+			fmt.Fprintf(&b, "  checked_after:  %s\n", fmtDebugTime(rule.CheckedAfter))
+		}
+		if rule.CheckedBefore != nil {
+			fmt.Fprintf(&b, "  checked_before: %s\n", fmtDebugTime(rule.CheckedBefore))
+		}
+
+		b.WriteString("  tasks:\n")
+		for _, tc := range rule.Tasks {
+			mark := "FAIL"
+			if tc.Pass {
+				mark = "PASS"
+			}
+			fmt.Fprintf(&b, "    [%s] %-24s state=%-40s actual=%s  expected=%s\n",
+				mark, tc.TaskID, tc.State, fmtDebugTime(tc.CheckedAt), expectedDesc(rule, tc))
+		}
+
+		fmt.Fprintf(&b, "  count (passed): %d", rule.Count)
+		if rule.MinRequired > 0 {
+			fmt.Fprintf(&b, " / required %d", rule.MinRequired)
+		}
+		b.WriteString("\n")
+		switch {
+		case rule.Applies:
+			fmt.Fprintf(&b, "  => APPLIED: %+d point(s)\n\n", rule.AppliedEffect)
+		case rule.IsActive:
+			b.WriteString("  => not applied yet (deadline still open)\n\n")
+		default:
+			b.WriteString("  => not applied\n\n")
+		}
+	}
+
+	fmt.Fprintf(&b, "%s\nTOTAL applied effect: %+d point(s)\n", strings.Repeat("=", 72), resp.TotalEffect)
+	return b.String()
+}
+
+// expectedDesc describes the deadline a task is compared against for the rule's
+// condition, so each task line is self-explanatory.
+func expectedDesc(rule EvaluationDebug, tc TaskCheckDebug) string {
+	switch rule.ConditionKind {
+	case "min_checked_before", "before":
+		return "before " + fmtDebugTime(rule.CheckedBefore)
+	case "after":
+		return "before " + fmtDebugTime(rule.CheckedAfter) + " (else late)"
+	case "interval":
+		return "between " + fmtDebugTime(rule.CheckedAfter) + " and " + fmtDebugTime(rule.CheckedBefore)
+	default:
+		return "n/a"
+	}
+}

--- a/templates/user.html
+++ b/templates/user.html
@@ -113,11 +113,16 @@
 <section class="mb-8">
   <div class="text-xs text-gray-500 mb-2 flex justify-between items-center">
     <span>// score rules</span>
-    {{ if ne .TotalEffect 0 }}
-  <span class="text-xs {{ if gt .TotalEffect 0 }}text-green-400{{ else }}text-red-400{{ end }}">
-    total effect: {{ if gt .TotalEffect 0 }}+{{ end }}{{ .TotalEffect }} point(s)
+    <span class="flex items-center space-x-3">
+      {{ if ne .TotalEffect 0 }}
+    <span class="text-xs {{ if gt .TotalEffect 0 }}text-green-400{{ else }}text-red-400{{ end }}">
+      total effect: {{ if gt .TotalEffect 0 }}+{{ end }}{{ .TotalEffect }} point(s)
+    </span>
+    {{ end }}
+    <a class="text-blue-400 hover:text-blue-300 text-xs"
+       href="/user/{{ .ID }}/score-debug?format=text"
+       target="_blank">[debug]</a>
   </span>
-  {{ end }}
 </div>
 <div class="bg-gray-800 rounded border border-gray-700 overflow-x-auto">
   <table class="w-full text-xs">

--- a/tests/run-hurl.sh
+++ b/tests/run-hurl.sh
@@ -123,6 +123,10 @@ run_test tests/ui/teacher-note.hurl \
     --variable "student_id=${TIMESTAMP}21" \
     --variable "teacher_id=$TEACHER_ID"
 
+run_test tests/ui/score-rules-debug.hurl \
+    --variable "student_id=${TIMESTAMP}22" \
+    --variable "teacher_id=$TEACHER_ID"
+
 # Stop server
 kill "$SERVER_PID" 2>/dev/null
 rm -f "$TEST_DB"

--- a/tests/ui/score-rules-debug.hurl
+++ b/tests/ui/score-rules-debug.hurl
@@ -1,0 +1,102 @@
+# Score Rules Debug Endpoint
+#
+# Covers GET /user/{id}/score-debug — the trace that shows, per rule, the actual
+# checked time vs the expected deadline, pass/fail per task, the counted number,
+# and the rule result. Verifies both the plain-text and JSON renderings plus
+# access control.
+#
+# Receives base_url, teacher_id, student_id from the runner.
+
+# Student signs up.
+POST {{base_url}}/signup
+[Options]
+variable: student_password=StudentPass123!
+variable: teacher_password=TeacherPass123!
+variable: student_username=ScoreDebug Student
+variable: other_id=999000222
+[FormParams]
+id: {{student_id}}
+password: {{student_password}}
+username: {{student_username}}
+
+HTTP 303
+[Captures]
+student_token: cookie "user_data"
+
+GET {{base_url}}/logout
+HTTP 303
+
+# A second student (to check cross-student access is forbidden).
+POST {{base_url}}/signup
+[FormParams]
+id: {{other_id}}
+password: {{student_password}}
+username: ScoreDebug Other
+
+HTTP 303
+[Captures]
+other_token: cookie "user_data"
+
+GET {{base_url}}/logout
+HTTP 303
+
+# Teacher signs in.
+POST {{base_url}}/signin
+[FormParams]
+id: {{teacher_id}}
+password: {{teacher_password}}
+
+HTTP 303
+[Captures]
+teacher_token: cookie "user_data"
+
+GET {{base_url}}/logout
+HTTP 303
+
+# --- Plain-text trace (teacher viewing the student) ---
+GET {{base_url}}/user/{{student_id}}/score-debug?format=text
+Cookie: user_data={{teacher_token}}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "text/plain"
+body contains "score-rule debug for @ScoreDebug Student"
+body contains "Lab 1 hard deadline"
+body contains "Mid-semester checkpoint"
+body contains "condition: min_checked_before"
+body contains "expected=before"
+body contains "<never accepted>"
+body contains "TOTAL applied effect:"
+
+# --- JSON trace ---
+GET {{base_url}}/user/{{student_id}}/score-debug
+Cookie: user_data={{teacher_token}}
+
+HTTP 200
+[Asserts]
+header "Content-Type" contains "application/json"
+jsonpath "$.user_id" == "{{student_id}}"
+jsonpath "$.username" == "ScoreDebug Student"
+jsonpath "$.rules" count == 6
+jsonpath "$.rules[0].rule" exists
+jsonpath "$.rules[0].condition_kind" exists
+jsonpath "$.rules[0].tasks" exists
+
+# --- A student may inspect their own evaluation ---
+GET {{base_url}}/user/{{student_id}}/score-debug?format=text
+Cookie: user_data={{student_token}}
+
+HTTP 200
+[Asserts]
+body contains "TOTAL applied effect:"
+
+# --- A student may NOT inspect another student's evaluation ---
+GET {{base_url}}/user/{{student_id}}/score-debug
+Cookie: user_data={{other_token}}
+
+HTTP 403
+
+# --- Unauthenticated access is rejected ---
+GET {{base_url}}/user/{{student_id}}/score-debug
+
+HTTP 401


### PR DESCRIPTION
## What

Adds a read-only debug view explaining a student's score-rule evaluation.

**`GET /user/{userID}/score-debug`** — JSON by default, plain text with `?format=text`. For every rule it shows, per task:
- the actual checked time vs the expected deadline,
- the **record state** it came from (`Checked` / `not checked (Pending)` / `not submitted`),
- pass/fail, the counted number, and the rule verdict + total effect.

A `[debug]` link is added to the `// score rules` section (opens the text trace).

## How

The trace is emitted on the real `EvaluateForStudent` path (no logic duplication), so it faithfully reflects actual grading. Access mirrors the profile page: students see only their own evaluation, teachers see anyone.

## Tests

`tests/ui/score-rules-debug.hurl` covers the text + JSON output and access control (403/401), wired into `run-hurl.sh` and the Makefile.

## Notes

Pure tooling — **no grading behavior changes**. The follow-up PR (`feat/score-eval-unregistered`) is stacked on this one.