### PR TITLE
feat: count tasks scored without a lesson registration

### DIFF
--- a/src/handlers/scorerule.go
+++ b/src/handlers/scorerule.go
@@ -27,24 +27,6 @@ func taskStatusLabel(s storage.TaskRecordStatus) string {
 	}
 }
 
-// latestCheckedTime returns the timestamp at which a task counts as "checked"
-// for score-rule purposes, or nil if it was never checked. See latestCheckedInfo.
-func latestCheckedTime(records []storage.TaskRecord) *time.Time {
-	at, _ := latestCheckedInfo(records)
-	return at
-}
-
-// latestCheckedInfo returns the checked time and a human-readable description of
-// the record state it was derived from (or why no checked time exists). records
-// must be newest-first, as returned by DB.ListTaskRecords.
-//
-// The usual path: a task is accepted by checking a lesson registration, which
-// produces a ReviewedTaskRecord whose CreatedAt is the student's submission
-// time. But a teacher can also score a task that was never registered to a
-// lesson — that leaves the student's submission Dropped plus a Feedback (review)
-// record carrying the score, and no ReviewedTaskRecord at all. In that case we
-// fall back to the newest student submission time: the work was checked, just
-// not through a lesson.
 func latestCheckedInfo(records []storage.TaskRecord) (*time.Time, string) {
 	if len(records) == 0 {
 		return nil, "not submitted"

--- a/src/handlers/scorerule.go
+++ b/src/handlers/scorerule.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ryukzak/slap/src/config"
 	"github.com/ryukzak/slap/src/storage"
+	"github.com/ryukzak/slap/src/util"
 )
 
 // taskStatusLabel maps a stored record status to the label shown in the UI.
@@ -24,6 +25,57 @@ func taskStatusLabel(s storage.TaskRecordStatus) string {
 	default:
 		return string(s)
 	}
+}
+
+// latestCheckedTime returns the timestamp at which a task counts as "checked"
+// for score-rule purposes, or nil if it was never checked. See latestCheckedInfo.
+func latestCheckedTime(records []storage.TaskRecord) *time.Time {
+	at, _ := latestCheckedInfo(records)
+	return at
+}
+
+// latestCheckedInfo returns the checked time and a human-readable description of
+// the record state it was derived from (or why no checked time exists). records
+// must be newest-first, as returned by DB.ListTaskRecords.
+//
+// The usual path: a task is accepted by checking a lesson registration, which
+// produces a ReviewedTaskRecord whose CreatedAt is the student's submission
+// time. But a teacher can also score a task that was never registered to a
+// lesson — that leaves the student's submission Dropped plus a Feedback (review)
+// record carrying the score, and no ReviewedTaskRecord at all. In that case we
+// fall back to the newest student submission time: the work was checked, just
+// not through a lesson.
+func latestCheckedInfo(records []storage.TaskRecord) (*time.Time, string) {
+	if len(records) == 0 {
+		return nil, "not submitted"
+	}
+
+	for i := range records {
+		if records[i].Status == storage.ReviewedTaskRecord {
+			return &records[i].CreatedAt, "Checked"
+		}
+	}
+
+	// No accepted record. If a teacher left a scored review, treat the work as
+	// checked at the time of the student's latest submission.
+	scored := false
+	for i := range records {
+		r := records[i]
+		if r.EntryAuthorID != r.StudentID && util.ExtractScore(r.Content) != "" {
+			scored = true
+			break
+		}
+	}
+	if scored {
+		for i := range records {
+			if records[i].EntryAuthorID == records[i].StudentID {
+				return &records[i].CreatedAt, "scored without lesson (submission " + taskStatusLabel(records[i].Status) + ")"
+			}
+		}
+		return nil, "scored, but no student submission found"
+	}
+
+	return nil, "not checked (" + taskStatusLabel(records[0].Status) + ")"
 }
 
 type Evaluation struct {

--- a/src/handlers/scorerule_debug.go
+++ b/src/handlers/scorerule_debug.go
@@ -53,16 +53,15 @@ func ScoreRulesDebugHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Same checked-time source as the profile page (src/handlers/user.go): the
-	// CreatedAt of the newest accepted (Checked) record. The state label (and
-	// read) is cached so each task is loaded only once.
+	// Same checked-time source as the profile page (src/handlers/user.go). The
+	// state label (and read) is cached so each task is loaded only once.
 	stateCache := map[storage.TaskID]string{}
 	getCheckedTime := func(taskID storage.TaskID) (*time.Time, error) {
 		records, err := DB.ListTaskRecords(profileUserID, taskID)
 		if err != nil {
 			return nil, err
 		}
-		at, state := debugCheckedInfo(records)
+		at, state := latestCheckedInfo(records)
 		stateCache[taskID] = state
 		return at, nil
 	}
@@ -107,21 +106,6 @@ func ScoreRulesDebugHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-// debugCheckedInfo returns the checked time (CreatedAt of the newest accepted
-// record, matching the profile page) plus a label describing the record state
-// it came from, or why none exists. records must be newest-first.
-func debugCheckedInfo(records []storage.TaskRecord) (*time.Time, string) {
-	if len(records) == 0 {
-		return nil, "not submitted"
-	}
-	for i := range records {
-		if records[i].Status == storage.ReviewedTaskRecord {
-			return &records[i].CreatedAt, "Checked"
-		}
-	}
-	return nil, "not checked (" + taskStatusLabel(records[0].Status) + ")"
-}
-
 // fmtDebugTime renders a timestamp in the primary timezone, or "<never>" for a
 // task that was never accepted.
 func fmtDebugTime(t *time.Time) string {
@@ -139,7 +123,8 @@ func renderScoreDebugText(resp ScoreRulesDebugResponse) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "score-rule debug for @%s (id %s)\n", resp.Username, resp.UserID)
 	fmt.Fprintf(&b, "now: %s  (timezone: %s)\n", fmtDebugTime(&resp.Now), resp.Timezone)
-	fmt.Fprintf(&b, "checked time = submission time (CreatedAt) of the newest accepted (Checked) record\n")
+	fmt.Fprintf(&b, "checked time = student's submission time of the accepted (Checked) work,\n")
+	fmt.Fprintf(&b, "               or, if scored without a lesson, the latest submission time\n")
 	b.WriteString(strings.Repeat("=", 72) + "\n\n")
 
 	for _, rule := range resp.Rules {

--- a/src/handlers/scorerule_eval_test.go
+++ b/src/handlers/scorerule_eval_test.go
@@ -1,0 +1,91 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ryukzak/slap/src/storage"
+)
+
+// rec is a small helper to build a TaskRecord with the fields latestCheckedInfo
+// looks at.
+func rec(status storage.TaskRecordStatus, author, student, content string, at time.Time) storage.TaskRecord {
+	return storage.TaskRecord{
+		Status:        status,
+		EntryAuthorID: author,
+		StudentID:     student,
+		Content:       content,
+		CreatedAt:     at,
+	}
+}
+
+func TestLatestCheckedInfo(t *testing.T) {
+	t0 := time.Date(2026, 5, 1, 10, 0, 0, 0, time.UTC)
+	t1 := t0.Add(24 * time.Hour)
+	t2 := t1.Add(24 * time.Hour)
+
+	tests := []struct {
+		name      string
+		records   []storage.TaskRecord // newest-first
+		wantAt    *time.Time
+		wantState string
+	}{
+		{
+			name:      "no records",
+			records:   nil,
+			wantAt:    nil,
+			wantState: "not submitted",
+		},
+		{
+			name: "submitted but not checked",
+			records: []storage.TaskRecord{
+				rec(storage.SubmitTaskRecord, "s", "s", "work", t0),
+			},
+			wantAt:    nil,
+			wantState: "not checked (Pending)",
+		},
+		{
+			name: "accepted via lesson uses submission time",
+			records: []storage.TaskRecord{
+				rec(storage.ReviewTaskRecord, "teacher", "s", "8 ok", t2),
+				rec(storage.ReviewedTaskRecord, "s", "s", "work", t1),
+			},
+			wantAt:    &t1,
+			wantState: "Checked",
+		},
+		{
+			name: "scored without lesson falls back to latest submission",
+			records: []storage.TaskRecord{
+				rec(storage.ReviewTaskRecord, "teacher", "s", "8 good", t2),
+				rec(storage.RevokedTaskRecord, "s", "s", "work", t1),
+			},
+			wantAt:    &t1,
+			wantState: "scored without lesson (submission Dropped)",
+		},
+		{
+			name: "feedback without a score does not count",
+			records: []storage.TaskRecord{
+				rec(storage.ReviewTaskRecord, "teacher", "s", "please revise", t2),
+				rec(storage.RevokedTaskRecord, "s", "s", "work", t1),
+			},
+			wantAt:    nil,
+			wantState: "not checked (Feedback)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			at, state := latestCheckedInfo(tt.records)
+			if tt.wantAt == nil {
+				if at != nil {
+					t.Errorf("checked time = %v, want nil", at)
+				}
+			} else if at == nil || !at.Equal(*tt.wantAt) {
+				t.Errorf("checked time = %v, want %v", at, *tt.wantAt)
+			}
+			if state != tt.wantState {
+				t.Errorf("state = %q, want %q", state, tt.wantState)
+			}
+		})
+	}
+}

--- a/src/handlers/user.go
+++ b/src/handlers/user.go
@@ -89,12 +89,7 @@ func UserInfoHandler(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				return nil, err
 			}
-			for _, record := range records {
-				if record.Status == storage.ReviewedTaskRecord {
-					return &record.CreatedAt, nil
-				}
-			}
-			return nil, nil
+			return latestCheckedTime(records), nil
 		}
 
 		evaluator := NewEvaluator(AppConfig)
@@ -751,12 +746,7 @@ func calculateStudentTotalEffectWithRecords(allRecords map[storage.TaskID][]stor
 		if !ok {
 			return nil, nil
 		}
-		for _, record := range records {
-			if record.Status == storage.ReviewedTaskRecord {
-				return &record.CreatedAt, nil
-			}
-		}
-		return nil, nil
+		return latestCheckedTime(records), nil
 	}
 
 	evaluator := NewEvaluator(AppConfig)

--- a/src/handlers/user.go
+++ b/src/handlers/user.go
@@ -89,7 +89,8 @@ func UserInfoHandler(w http.ResponseWriter, r *http.Request) {
 			if err != nil {
 				return nil, err
 			}
-			return latestCheckedTime(records), nil
+			at, _ := latestCheckedInfo(records)
+			return at, nil
 		}
 
 		evaluator := NewEvaluator(AppConfig)
@@ -746,7 +747,8 @@ func calculateStudentTotalEffectWithRecords(allRecords map[storage.TaskID][]stor
 		if !ok {
 			return nil, nil
 		}
-		return latestCheckedTime(records), nil
+		at, _ := latestCheckedInfo(records)
+		return at, nil
 	}
 
 	evaluator := NewEvaluator(AppConfig)


### PR DESCRIPTION
## What

Fixes a gap where a task **scored by a teacher without a lesson registration** did not count toward any score rule.

Normally a task is Checked by accepting a lesson registration → a `ReviewedTaskRecord` whose `CreatedAt` counts. But a teacher can also score a task that was never registered: that leaves the submission **Dropped** plus a **Feedback** record carrying the score, with **no** `ReviewedTaskRecord` — so the work counted nowhere.

## How

`latestCheckedInfo`/`latestCheckedTime`:
1. accepted (`Checked`) record → its `CreatedAt` (unchanged behavior), else
2. a teacher review **with a score** → fall back to the student's **latest submission** time, else
3. `nil` (a plain Feedback **without** a score still does not count).

Applied to the **profile page** and **CSV** grading, and the debug endpoint is wired through it so the debug view keeps mirroring grading (and now reports the `scored without lesson` state).

## Tests

`TestLatestCheckedInfo` covers all five cases (accepted, scored-no-lesson, unscored feedback, pending, none).

## Notes

- ⚠️ **This changes the real penalty calculation** (profile + CSV): a scored-but-unregistered task now counts toward checkpoints.
- **Stacked on #50** — review/merge that first; this PR's diff is only the evaluation change.
- Distinct from the issue #48 retroactive-revocation bug, which is left untouched.