### PR TITLE
refactor: simplify score-rule evaluation

### DIFF
--- a/src/handlers/scorerule.go
+++ b/src/handlers/scorerule.go
@@ -107,6 +107,24 @@ func NewEvaluator(cfg *config.Config) *Evaluator {
 	return &Evaluator{config: cfg}
 }
 
+// checkedBefore reports whether a task's checked time exists and is before cutoff.
+func checkedBefore(t *time.Time, cutoff time.Time) bool {
+	return t != nil && t.Before(cutoff)
+}
+
+// markPasses sets Pass on each task to pred(checkedTime) and returns the number
+// that passed.
+func markPasses(tasks []TaskCheckDebug, pred func(*time.Time) bool) int {
+	n := 0
+	for i := range tasks {
+		tasks[i].Pass = pred(tasks[i].CheckedAt)
+		if tasks[i].Pass {
+			n++
+		}
+	}
+	return n
+}
+
 // EvaluateForStudent evaluates a rule at a specific point in time.
 //
 // The branch order below is significant and preserved as-is: a rule with both
@@ -137,64 +155,41 @@ func (e *Evaluator) EvaluateForStudent(rule config.ScoreRule, now time.Time, get
 		tasks = append(tasks, TaskCheckDebug{TaskID: taskID, CheckedAt: t})
 	}
 
+	c := rule.Condition
 	switch {
-	// Min checked before
-	case rule.Condition.MinCheckedBefore > 0:
+	// Penalty if fewer than N of the tasks are checked before the deadline.
+	case c.MinCheckedBefore > 0:
 		dbg.ConditionKind = "min_checked_before"
-		countBefore := 0
-		for i := range tasks {
-			pass := tasks[i].CheckedAt != nil && tasks[i].CheckedAt.Before(*rule.Condition.CheckedBefore)
-			tasks[i].Pass = pass
-			if pass {
-				countBefore++
-			}
-		}
-		eval.CountBefore = countBefore
-
-		if countBefore < rule.Condition.MinCheckedBefore {
-			eval.IsActive = !now.After(*rule.Condition.CheckedBefore)
+		eval.CountBefore = markPasses(tasks, func(t *time.Time) bool { return checkedBefore(t, *c.CheckedBefore) })
+		if eval.CountBefore < c.MinCheckedBefore {
+			eval.IsActive = !now.After(*c.CheckedBefore)
 			eval.Applies = !eval.IsActive
 		}
 
-	// After
-	case rule.Condition.CheckedAfter != nil && rule.Condition.CheckedBefore == nil:
+	// Penalty if any task is checked after the deadline (i.e. not all on time).
+	// Equivalent to a min_checked_before of len(tasks) with CheckedAfter as the
+	// deadline.
+	case c.CheckedAfter != nil && c.CheckedBefore == nil:
 		dbg.ConditionKind = "after"
-		allCheckedBefore := true
-		for i := range tasks {
-			onTime := tasks[i].CheckedAt != nil && tasks[i].CheckedAt.Before(*rule.Condition.CheckedAfter)
-			tasks[i].Pass = onTime
-			if !onTime {
-				allCheckedBefore = false
-			}
-		}
-		eval.IsActive = !now.After(*rule.Condition.CheckedAfter)
-		eval.Applies = !eval.IsActive && !allCheckedBefore
+		onTime := markPasses(tasks, func(t *time.Time) bool { return checkedBefore(t, *c.CheckedAfter) })
+		eval.IsActive = !now.After(*c.CheckedAfter)
+		eval.Applies = !eval.IsActive && onTime < len(tasks)
 
-	// Before
-	case rule.Condition.CheckedBefore != nil && rule.Condition.MinCheckedBefore == 0:
+	// Bonus as soon as any task is checked before the deadline. Also handles a
+	// rule with both bounds (no min): the "interval" case below is shadowed.
+	case c.CheckedBefore != nil:
 		dbg.ConditionKind = "before"
-		hasCheckedBefore := false
-		for i := range tasks {
-			pass := tasks[i].CheckedAt != nil && tasks[i].CheckedAt.Before(*rule.Condition.CheckedBefore)
-			tasks[i].Pass = pass
-			if pass {
-				hasCheckedBefore = true
-			}
-		}
-		eval.IsActive = !now.After(*rule.Condition.CheckedBefore)
-		eval.Applies = hasCheckedBefore
+		eval.IsActive = !now.After(*c.CheckedBefore)
+		eval.Applies = markPasses(tasks, func(t *time.Time) bool { return checkedBefore(t, *c.CheckedBefore) }) > 0
 
-	// Interval
-	case rule.Condition.CheckedAfter != nil && rule.Condition.CheckedBefore != nil:
+	// Unreachable today (the "before" case above already matches both bounds).
+	// Kept to document the intended interval rule; firing it needs a routing
+	// decision first.
+	case c.CheckedAfter != nil && c.CheckedBefore != nil:
 		dbg.ConditionKind = "interval"
-		for i := range tasks {
-			t := tasks[i].CheckedAt
-			pass := t != nil && t.After(*rule.Condition.CheckedAfter) && t.Before(*rule.Condition.CheckedBefore)
-			tasks[i].Pass = pass
-			if pass {
-				eval.Applies = true
-			}
-		}
+		eval.Applies = markPasses(tasks, func(t *time.Time) bool {
+			return t != nil && t.After(*c.CheckedAfter) && t.Before(*c.CheckedBefore)
+		}) > 0
 
 	default:
 		dbg.ConditionKind = "none"

--- a/src/handlers/scorerule_evaluate_test.go
+++ b/src/handlers/scorerule_evaluate_test.go
@@ -1,0 +1,146 @@
+package handlers
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ryukzak/slap/src/config"
+	"github.com/ryukzak/slap/src/storage"
+)
+
+// These tests pin the observable behaviour of EvaluateForStudent (Applies /
+// IsActive / Status) for every condition kind, so the evaluation core can be
+// refactored without changing what students see.
+func TestEvaluateForStudent(t *testing.T) {
+	d := time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC)
+	beforeD := d.Add(-time.Hour)
+	afterD := d.Add(time.Hour)
+	nowBefore := d.Add(-2 * time.Hour)
+	nowAfter := d.Add(2 * time.Hour)
+
+	tp := func(t time.Time) *time.Time { return &t }
+
+	tests := []struct {
+		name       string
+		rule       config.ScoreRule
+		now        time.Time
+		checked    map[storage.TaskID]*time.Time
+		wantApply  bool
+		wantActive bool
+		wantStatus string
+	}{
+		{
+			name: "min_checked_before: enough checked -> not applied",
+			rule: config.ScoreRule{TaskIDs: []storage.TaskID{"a", "b", "c"}, Effect: -1,
+				Condition: config.Condition{MinCheckedBefore: 2, CheckedBefore: &d}},
+			now:        nowAfter,
+			checked:    map[storage.TaskID]*time.Time{"a": tp(beforeD), "b": tp(beforeD)},
+			wantApply:  false,
+			wantActive: false,
+			wantStatus: "not_applied",
+		},
+		{
+			name: "min_checked_before: too few and deadline passed -> applied",
+			rule: config.ScoreRule{TaskIDs: []storage.TaskID{"a", "b", "c"}, Effect: -1,
+				Condition: config.Condition{MinCheckedBefore: 2, CheckedBefore: &d}},
+			now:        nowAfter,
+			checked:    map[storage.TaskID]*time.Time{"a": tp(beforeD)},
+			wantApply:  true,
+			wantActive: false,
+			wantStatus: "applied",
+		},
+		{
+			name: "min_checked_before: too few but deadline open -> active",
+			rule: config.ScoreRule{TaskIDs: []storage.TaskID{"a", "b", "c"}, Effect: -1,
+				Condition: config.Condition{MinCheckedBefore: 2, CheckedBefore: &d}},
+			now:        nowBefore,
+			checked:    map[storage.TaskID]*time.Time{"a": tp(beforeD)},
+			wantApply:  false,
+			wantActive: true,
+			wantStatus: "active",
+		},
+		{
+			name: "after: all on time -> not applied",
+			rule: config.ScoreRule{TaskIDs: []storage.TaskID{"a", "b"}, Effect: -2,
+				Condition: config.Condition{CheckedAfter: &d}},
+			now:        nowAfter,
+			checked:    map[storage.TaskID]*time.Time{"a": tp(beforeD), "b": tp(beforeD)},
+			wantApply:  false,
+			wantActive: false,
+			wantStatus: "not_applied",
+		},
+		{
+			name: "after: one late and deadline passed -> applied",
+			rule: config.ScoreRule{TaskIDs: []storage.TaskID{"a", "b"}, Effect: -2,
+				Condition: config.Condition{CheckedAfter: &d}},
+			now:        nowAfter,
+			checked:    map[storage.TaskID]*time.Time{"a": tp(beforeD), "b": tp(afterD)},
+			wantApply:  true,
+			wantActive: false,
+			wantStatus: "applied",
+		},
+		{
+			name: "after: deadline still open -> active",
+			rule: config.ScoreRule{TaskIDs: []storage.TaskID{"a"}, Effect: -2,
+				Condition: config.Condition{CheckedAfter: &d}},
+			now:        nowBefore,
+			checked:    map[storage.TaskID]*time.Time{"a": tp(afterD)},
+			wantApply:  false,
+			wantActive: true,
+			wantStatus: "active",
+		},
+		{
+			name: "before (bonus): checked in time -> applied immediately",
+			rule: config.ScoreRule{TaskIDs: []storage.TaskID{"a"}, Effect: 1,
+				Condition: config.Condition{CheckedBefore: &d}},
+			now:        nowBefore,
+			checked:    map[storage.TaskID]*time.Time{"a": tp(beforeD)},
+			wantApply:  true,
+			wantActive: true,
+			wantStatus: "applied",
+		},
+		{
+			name: "before (bonus): not checked in time -> not applied",
+			rule: config.ScoreRule{TaskIDs: []storage.TaskID{"a"}, Effect: 1,
+				Condition: config.Condition{CheckedBefore: &d}},
+			now:        nowAfter,
+			checked:    map[storage.TaskID]*time.Time{"a": tp(afterD)},
+			wantApply:  false,
+			wantActive: false,
+			wantStatus: "not_applied",
+		},
+		{
+			// Documents CURRENT behaviour: a rule with both bounds and no min is
+			// handled by the "before" branch (the "interval" branch is shadowed),
+			// so a task checked before the lower bound still counts.
+			name: "both bounds, no min: currently treated as before",
+			rule: config.ScoreRule{TaskIDs: []storage.TaskID{"a"}, Effect: -1,
+				Condition: config.Condition{CheckedAfter: &d, CheckedBefore: tp(d.Add(10 * time.Hour))}},
+			now:        nowAfter,
+			checked:    map[storage.TaskID]*time.Time{"a": tp(beforeD)}, // before the lower bound
+			wantApply:  true,
+			wantActive: true, // IsActive comes from the far-future CheckedBefore in the "before" branch
+			wantStatus: "applied",
+		},
+	}
+
+	evaluator := NewEvaluator(&config.Config{})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			get := func(id storage.TaskID) (*time.Time, error) { return tt.checked[id], nil }
+			ev, err := evaluator.EvaluateForStudent(tt.rule, tt.now, get)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ev.Applies != tt.wantApply {
+				t.Errorf("Applies = %v, want %v", ev.Applies, tt.wantApply)
+			}
+			if ev.IsActive != tt.wantActive {
+				t.Errorf("IsActive = %v, want %v", ev.IsActive, tt.wantActive)
+			}
+			if got := ev.Status(); got != tt.wantStatus {
+				t.Errorf("Status = %q, want %q", got, tt.wantStatus)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Follow-up cleanup on top of #50/#51.

## What

`EvaluateForStudent` had four near-identical per-task loops. Extract a single per-task predicate (`checkedBefore`) and a `markPasses` helper, collapsing each condition kind to a couple of lines.

## Behavior

Unchanged — pinned by a new table-driven test (`TestEvaluateForStudent`) covering every condition kind: `min_checked_before`, `after`, `before` (bonus), and the currently-shadowed `interval` case (incl. active/applied/not-applied and the deadline-gating).

## Notes from the cleanup

Comments now record two facts the old structure hid:
- **`after` is just `min_checked_before` with N = len(tasks)** (CheckedAfter acts as the deadline). Could be merged later if desired.
- **The `interval` branch is unreachable** — a rule with both bounds and no `min` is handled by the `before` branch. Firing real interval semantics needs a routing decision (and would change behavior for such rules), so it's left as-is and flagged. Your `Lab 1 soft deadline` example config currently evaluates as `before`, not interval.