### PR TITLE
fix(storage): show lesson list right after revoke

### DIFF
--- a/src/storage/flow_test.go
+++ b/src/storage/flow_test.go
@@ -87,6 +87,8 @@ func TestRevokeResubmitsAsPending(t *testing.T) {
 	records, err := db.ListTaskRecords(student.ID, taskID)
 	assert.NoError(t, err)
 	assert.Len(t, records, 2, "revoke should append a new pending record, keeping the dropped one")
+	assert.Equal(t, SubmitTaskRecord, records[0].Status,
+		"the pending resubmission must sort as the newest record despite sharing CreatedAt with the dropped one")
 
 	// records are newest-first; locate each by status.
 	var dropped, pending *TaskRecord

--- a/src/storage/task.go
+++ b/src/storage/task.go
@@ -42,10 +42,13 @@ func (r *TaskRecord) RenderAt() string {
 	return r.CreatedAt.Format("2006-01-02 15:04:05")
 }
 
-// Both sorts are stable: a revoke leaves the dropped record in place and
-// appends a fresh pending record that carries the original CreatedAt (so the
-// student keeps their queue position). That makes ties on CreatedAt normal, and
-// a stable sort keeps such ties in index (append) order instead of flickering.
+// Both sorts are stable and expect records in index (append) order: a revoke
+// leaves the dropped record in place and appends a fresh pending record that
+// carries the original CreatedAt (so the student keeps their queue position).
+// That makes ties on CreatedAt normal; on a tie the later-appended record is
+// the newer one, so oldest-first keeps append order while newest-first must
+// reverse it — otherwise the dropped record would shadow the pending
+// resubmission as the latest record.
 func SortTaskRecordsOldestFirst(records []*TaskRecord) {
 	sort.SliceStable(records, func(i, j int) bool {
 		return records[i].CreatedAt.Before(records[j].CreatedAt)
@@ -53,6 +56,9 @@ func SortTaskRecordsOldestFirst(records []*TaskRecord) {
 }
 
 func SortTaskRecordsNewestFirst(records []TaskRecord) {
+	for i, j := 0, len(records)-1; i < j; i, j = i+1, j-1 {
+		records[i], records[j] = records[j], records[i]
+	}
 	sort.SliceStable(records, func(i, j int) bool {
 		return records[i].CreatedAt.After(records[j].CreatedAt)
 	})

--- a/tests/ui/reregistration-after-revoke.hurl
+++ b/tests/ui/reregistration-after-revoke.hurl
@@ -98,7 +98,10 @@ taskID: {{task_id}}
 
 HTTP 303
 
-# Scenario 1: task page keeps the Dropped record and shows a fresh Pending one
+# Scenario 1: task page keeps the Dropped record and shows a fresh Pending one.
+# The pending resubmission must be treated as the latest record, so the lesson
+# registration list is shown right away (the student keeps their queue position
+# and can re-register without submitting again).
 GET {{base_url}}/user/{{student_id}}/task/{{task_id}}
 Cookie: user_data={{student_token}}
 
@@ -106,6 +109,18 @@ HTTP 200
 [Asserts]
 body contains "Pending"
 body contains "Dropped"
+body contains "/api/lessons?register=1"
+
+# The lesson list the task page loads (via htmx) must offer lessons to
+# register to, right after the revoke.
+GET {{base_url}}/api/lessons?register=1&task_id={{task_id}}&student_id={{student_id}}
+Cookie: user_data={{student_token}}
+
+HTTP 200
+[Asserts]
+body contains "Lesson B resubmit test"
+body contains "[register]"
+body contains "/api/lesson/{{lesson_b_id}}/register"
 
 # Scenario 2: teacher's lesson A page shows Dropped in history
 GET {{base_url}}/lesson/{{lesson_a_id}}?showRevoked=true


### PR DESCRIPTION
## Problem

After clicking **[revoke]** on a queued submission, the task page stopped showing the lesson registration list. New lessons only appeared after adding a brand-new submission — which also reset the student's queue position, defeating the whole point of the revoke/resubmit mechanic.

## Root cause

A revoke marks the old record as Dropped and appends a fresh Pending record that intentionally keeps the original `CreatedAt` (this is how the student keeps their place in the submit-ordered queue). But `SortTaskRecordsNewestFirst` broke the resulting `CreatedAt` tie in favor of the earlier-appended (Dropped) record, so `TaskDetailHandler` treated "Dropped" as the latest status and the template hid the `// register` section entirely.

## Fix

`SortTaskRecordsNewestFirst` now breaks `CreatedAt` ties by append order reversed: the later-appended record (the pending resubmission) sorts as the newest. The lesson list shows immediately after a revoke, and the queue position is still preserved by the original timestamp. This also fixes the same stale latest-status display anywhere else `ListTaskRecords` order is used (profile, dashboard).

## Tests (TDD per CLAUDE.md)

- Extended `tests/ui/reregistration-after-revoke.hurl`: after revoke, the task page must contain the lesson loader (`/api/lessons?register=1`), and the lesson list endpoint must return registerable lessons with `[register]` actions. Confirmed it failed before the fix and passes after.
- Strengthened `TestRevokeResubmitsAsPending` to assert the pending resubmission sorts first in `ListTaskRecords`.
- Full suite green: all unit tests and all 22 hurl integration tests pass; `gofmt` clean.

No doc changes needed: pure bug fix, no new or changed functionality in `README.md` / `GUIDE.md` / `FEATURES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)