### PR TITLE
add expandable teacher notes history on lesson page

### DIFF
--- a/src/handlers/lesson.go
+++ b/src/handlers/lesson.go
@@ -80,8 +80,7 @@ type TaskRecordWithInfo struct {
 	ReviewRecords   []storage.TaskRecord
 	JournalRecords  []storage.TaskRecord
 	JournalSummary  string
-	LastNote        string
-	NoteCount       int
+	AllNotes        []storage.UserNote
 }
 
 // lessonRecordsData is the data passed to the lesson_task_records partial.
@@ -125,7 +124,7 @@ func buildLessonRecords(lesson *storage.Lesson, showRevoked bool, sortMode SortM
 
 	// Cache student notes so each student is looked up at most once.
 	noteCache := map[string][]storage.UserNote{}
-	lastNote := func(studentID string) (string, int) {
+	getAllNotes := func(studentID string) []storage.UserNote {
 		notes, ok := noteCache[studentID]
 		if !ok {
 			if u, err := DB.GetUser(studentID); err == nil {
@@ -133,10 +132,7 @@ func buildLessonRecords(lesson *storage.Lesson, showRevoked bool, sortMode SortM
 			}
 			noteCache[studentID] = notes
 		}
-		if len(notes) == 0 {
-			return "", 0
-		}
-		return notes[len(notes)-1].Content, len(notes)
+		return notes
 	}
 
 	allRecords := []TaskRecordWithInfo{}
@@ -187,7 +183,7 @@ func buildLessonRecords(lesson *storage.Lesson, showRevoked bool, sortMode SortM
 			summaryParts = append(summaryParts, fmt.Sprintf("@%s:%d", name, authorCounts[name]))
 		}
 
-		noteContent, noteCount := lastNote(taskRecord.StudentID)
+		allNotes := getAllNotes(taskRecord.StudentID)
 		allRecords = append(allRecords, TaskRecordWithInfo{
 			TaskRecord:      *taskRecord,
 			TaskTitle:       taskTitle,
@@ -196,8 +192,7 @@ func buildLessonRecords(lesson *storage.Lesson, showRevoked bool, sortMode SortM
 			ReviewRecords:   reviewRecords,
 			JournalRecords:  reverseSlice(allForTask),
 			JournalSummary:  strings.Join(summaryParts, " "),
-			LastNote:        noteContent,
-			NoteCount:       noteCount,
+			AllNotes:        allNotes,
 		})
 	}
 	for _, pr := range previousTaskRecords {
@@ -209,12 +204,11 @@ func buildLessonRecords(lesson *storage.Lesson, showRevoked bool, sortMode SortM
 		if task != nil {
 			taskTitle = task.Title
 		}
-		noteContent, noteCount := lastNote(pr.StudentID)
+		allNotes := getAllNotes(pr.StudentID)
 		allRecords = append(allRecords, TaskRecordWithInfo{
 			TaskRecord: *pr,
 			TaskTitle:  taskTitle,
-			LastNote:   noteContent,
-			NoteCount:  noteCount,
+			AllNotes:   allNotes,
 		})
 	}
 

--- a/templates/partials/lesson_task_records.html
+++ b/templates/partials/lesson_task_records.html
@@ -35,15 +35,24 @@
     </div>
   </summary>
   <div class="px-4 pb-4 pt-2">
-    {{ if and $.SessionIsTeacher $record.LastNote }}
-    <div class="mb-2 p-3 bg-gray-900 rounded border border-gray-700">
-      <div class="text-xs text-gray-500 mb-1">
-        // teacher note ({{ $record.NoteCount }})
-      </div>
-      <div class="text-xs markdown">
-        {{ markdown $record.LastNote }}
-      </div>
-    </div>
+    {{ if and $.SessionIsTeacher $record.AllNotes }}
+    <details class="mb-2 border border-gray-700 rounded">
+      <summary class="cursor-pointer list-none px-3 py-1 text-xs text-gray-500 hover:bg-gray-800 rounded">
+        // teacher notes ({{ len $record.AllNotes }})
+      </summary>
+      <ul class="px-3 pb-2 space-y-1">
+        {{ range $note := $record.AllNotes }}
+        <li class="border-b border-gray-800 py-1">
+          <div class="text-xs text-gray-500 mb-1">
+            {{ formatDateTime $note.CreatedAt }}
+          </div>
+          <div class="markdown text-xs">
+            {{ markdown $note.Content }}
+          </div>
+        </li>
+        {{ end }}
+      </ul>
+    </details>
     {{ end }}
     {{ if and $.SessionIsTeacher $record.JournalRecords }}
     <details class="mb-2 border border-gray-700 rounded">

--- a/tests/ui/teacher-note.hurl
+++ b/tests/ui/teacher-note.hurl
@@ -1,10 +1,11 @@
 # Teacher Note Test
 # Verifies teacher notes for a student:
 #   1. Any teacher can add notes; notes are an append-only list with author.
-#   2. The student page shows all notes (with author + count), teachers only.
-#   3. The student never sees the notes on their own page.
-#   4. The lesson page shows only the last note text (no author) plus a count,
-#      teachers only.
+#   2. The lesson page shows all notes (no author) inside a collapsible block
+#      with a total count, teachers only
+#   3. The student page shows all notes (with author) + count, teachers only.
+#   4. The student never sees the notes on their own page.
+#   
 #
 # Prerequisites: server running against a fresh DB with default config
 #   (teacher_ids: ["123"]).
@@ -114,15 +115,15 @@ studentID: {{student_id}}
 
 HTTP 200
 
-# Step 10: Teacher sees only the last note + count on the lesson page
+# Step 10: Teacher sees all notes + count on the lesson page
 GET {{base_url}}/lesson/{{lesson_id}}
 Cookie: user_data={{teacher_token}}
 
 HTTP 200
 [Asserts]
-body contains "teacher note (2)"
+body contains "teacher notes (2)"
 body contains "{{note_two}}"
-body not contains "{{note_one}}"
+body contains "{{note_one}}"
 
 # Step 11: Student does NOT see the notes on the lesson page
 GET {{base_url}}/lesson/{{lesson_id}}


### PR DESCRIPTION
1. The previous ui design for teacher notes wasnt expandable, only the last note was shown, there was a request to make it look like the journal expandable element

<img width="684" height="139" alt="image" src="https://github.com/user-attachments/assets/dec1568a-1f49-4631-9075-bb8517263dd6" />

2. Now the full history of notes is displayed inside a `<details>` block similarly to the journal
3. **Author names are hidden on the lesson page**. The block appears only if the student has notes. Author names can still be viewed on the user page, as this change doesnt affect that page

How it looks before and after expanding:

<img width="688" height="102" alt="image" src="https://github.com/user-attachments/assets/5efca9ab-fc35-40ab-963e-b1cc2e38cff6" />

<img width="687" height="208" alt="image" src="https://github.com/user-attachments/assets/0b5fb9ad-27c4-426a-b8d6-0f522bfd3da1" />
