### PR TITLE
feat: per-task waiting period in hours, shown on the task page

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -54,7 +54,9 @@ Note: role assignment happens at signup and is re-evaluated from config on every
    - The student must have an existing `submit` record for the task they want to register.
    - A per-task waiting period applies: a student cannot re-register a task until a configured
      number of hours has passed since their last teacher review of it. Set `waiting_period_hours`
-     per task in the config (defaults to 24h; `0` disables the threshold).
+     per task in the config (defaults to 24h; `0` disables the threshold). While the period is
+     active, the task page shows the remaining time in the `// register` section and the lesson
+     list marks each lesson `[not yet]` instead of offering a register button.
    - Only one registration per task per lesson at a time.
    - If the student updates their task after registering, the registration is automatically revoked.
    - Students can still register after the capacity limit is exceeded; they remain below the cutoff and can move up if someone above withdraws.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -52,6 +52,9 @@ Note: role assignment happens at signup and is re-evaluated from config on every
 2. Teacher adds a short description of the lesson to set student expectations.
 3. Student registers for the lesson before it starts — registration is blocked once the lesson begins.
    - The student must have an existing `submit` record for the task they want to register.
+   - A per-task waiting period applies: a student cannot re-register a task until a configured
+     number of hours has passed since their last teacher review of it. Set `waiting_period_hours`
+     per task in the config (defaults to 24h; `0` disables the threshold).
    - Only one registration per task per lesson at a time.
    - If the student updates their task after registering, the registration is automatically revoked.
    - Students can still register after the capacity limit is exceeded; they remain below the cutoff and can move up if someone above withdraws.

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,9 @@ test-hurl:
 	hurl --test $(HURL_VARS) \
 		--variable student_id=student_$$(date +%s)24 \
 		tests/ui/user-list-note-column.hurl
+	hurl --test $(HURL_VARS) \
+		--variable student_id=student_$$(date +%s)25 \
+		tests/ui/lesson-waiting-period.hurl
 
 # Build, start server with a temp DB, run Hurl tests, stop server.
 # Usage: make test-hurl-ci [TEST_PORT=18080] [TEACHER_ID=123]

--- a/conf/config.yaml
+++ b/conf/config.yaml
@@ -15,6 +15,9 @@ default_lesson_description: |
 tasks:
   - id: "task1"
     title: "Lab 1"
+    # Hours that must pass since the last teacher review before a student can
+    # re-register this task for a lesson. Omit for the 24h default; 0 disables it.
+    waiting_period_hours: 24
     description: |
       # Basic Data Structures
 

--- a/src/config/config.go
+++ b/src/config/config.go
@@ -37,10 +37,13 @@ type Condition struct {
 
 // Task represents a task in the system
 type Task struct {
-	ID            storage.TaskID `yaml:"id"`
-	Title         string         `yaml:"title"`
-	Description   string         `yaml:"description"`
-	WaitingPeriod *time.Duration `yaml:"waiting_period,omitempty"`
+	ID          storage.TaskID `yaml:"id"`
+	Title       string         `yaml:"title"`
+	Description string         `yaml:"description"`
+	// WaitingPeriodHours is the minimum number of hours that must pass since the
+	// last teacher review before a student may re-register the task for a lesson.
+	// When unset, DefaultWaitingPeriod applies. A value of 0 disables the check.
+	WaitingPeriodHours *int `yaml:"waiting_period_hours,omitempty"`
 }
 
 func (c *Config) IsTeacher(userID string) bool {
@@ -53,9 +56,10 @@ func (c *Config) IsTeacher(userID string) bool {
 }
 
 // GetWaitingPeriod returns the task's waiting period, defaulting to 24h.
+// A configured value of 0 hours disables the check (no threshold).
 func (t *Task) GetWaitingPeriod() time.Duration {
-	if t.WaitingPeriod != nil {
-		return *t.WaitingPeriod
+	if t.WaitingPeriodHours != nil {
+		return time.Duration(*t.WaitingPeriodHours) * time.Hour
 	}
 	return DefaultWaitingPeriod
 }
@@ -90,6 +94,9 @@ func LoadConfig(filePath string) (*Config, error) {
 		}
 		if task.Title == "" {
 			return nil, fmt.Errorf("task at index %d has an empty title", i)
+		}
+		if task.WaitingPeriodHours != nil && *task.WaitingPeriodHours < 0 {
+			return nil, fmt.Errorf("task %s has a negative waiting_period_hours (use 0 to disable)", task.ID)
 		}
 	}
 

--- a/src/config/config_test.go
+++ b/src/config/config_test.go
@@ -1,0 +1,79 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func writeTempConfig(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write temp config: %v", err)
+	}
+	return path
+}
+
+func intPtr(v int) *int { return &v }
+
+func TestGetWaitingPeriod(t *testing.T) {
+	tests := []struct {
+		name string
+		task Task
+		want time.Duration
+	}{
+		{"unset defaults to 24h", Task{}, DefaultWaitingPeriod},
+		{"explicit 48h", Task{WaitingPeriodHours: intPtr(48)}, 48 * time.Hour},
+		{"zero means no threshold", Task{WaitingPeriodHours: intPtr(0)}, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.task.GetWaitingPeriod(); got != tt.want {
+				t.Errorf("GetWaitingPeriod() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoadConfig_WaitingPeriodHours(t *testing.T) {
+	path := writeTempConfig(t, `
+tasks:
+  - id: "task1"
+    title: "Lab 1"
+    waiting_period_hours: 48
+  - id: "task2"
+    title: "Lab 2"
+    waiting_period_hours: 0
+  - id: "task3"
+    title: "Lab 3"
+`)
+	cfg, err := LoadConfig(path)
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+
+	if got := cfg.GetTask("task1").GetWaitingPeriod(); got != 48*time.Hour {
+		t.Errorf("task1 waiting period = %v, want 48h", got)
+	}
+	if got := cfg.GetTask("task2").GetWaitingPeriod(); got != 0 {
+		t.Errorf("task2 waiting period = %v, want 0 (no threshold)", got)
+	}
+	if got := cfg.GetTask("task3").GetWaitingPeriod(); got != DefaultWaitingPeriod {
+		t.Errorf("task3 waiting period = %v, want default %v", got, DefaultWaitingPeriod)
+	}
+}
+
+func TestLoadConfig_NegativeWaitingPeriodRejected(t *testing.T) {
+	path := writeTempConfig(t, `
+tasks:
+  - id: "task1"
+    title: "Lab 1"
+    waiting_period_hours: -5
+`)
+	if _, err := LoadConfig(path); err == nil {
+		t.Fatal("expected error for negative waiting_period_hours, got nil")
+	}
+}

--- a/src/handlers/lesson.go
+++ b/src/handlers/lesson.go
@@ -380,21 +380,9 @@ func RenderLessonListHandler(w http.ResponseWriter, r *http.Request) {
 		studentID := r.URL.Query().Get("student_id")
 		if taskID != "" && studentID != "" {
 			if task := AppConfig.GetTask(storage.TaskID(taskID)); task != nil {
-				wp := task.GetWaitingPeriod()
-				if wp > 0 {
-					records, err := DB.ListTaskRecords(studentID, taskID)
-					if err == nil {
-						for _, rec := range records {
-							if rec.Status == storage.ReviewTaskRecord {
-								if time.Since(rec.CreatedAt) < wp {
-									remaining := wp - time.Since(rec.CreatedAt)
-									hours := int(remaining.Hours())
-									minutes := int(remaining.Minutes()) % 60
-									waitingMessage = fmt.Sprintf("Waiting period: %dh%dm remaining since last check", hours, minutes)
-								}
-								break
-							}
-						}
+				if records, err := DB.ListTaskRecords(studentID, taskID); err == nil {
+					if remaining := waitingPeriodRemaining(task, records); remaining > 0 {
+						waitingMessage = formatWaitingMessage(remaining)
 					}
 				}
 			}

--- a/src/handlers/task.go
+++ b/src/handlers/task.go
@@ -58,6 +58,7 @@ func TaskDetailHandler(w http.ResponseWriter, r *http.Request) {
 		RegisteredLesson *storage.Lesson
 		QueuePosition    int
 		QueueTotal       int
+		WaitingMessage   string
 	}
 
 	model := TaskViewModel{
@@ -91,6 +92,10 @@ func TaskDetailHandler(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	model.TaskRecords = rawRecords
+
+	if remaining := waitingPeriodRemaining(task, rawRecords); remaining > 0 {
+		model.WaitingMessage = formatWaitingMessage(remaining)
+	}
 
 	var pending, queued, dropped, feedback, checked int
 	for _, r := range rawRecords {
@@ -131,6 +136,36 @@ func TaskDetailHandler(w http.ResponseWriter, r *http.Request) {
 	model.JournalSummary = strings.Join(parts, "\u00a0")
 
 	renderPage(w, "templates/task.html", model)
+}
+
+// waitingPeriodRemaining returns how long until the student may re-register the
+// task, based on the most recent teacher review and the task's configured
+// waiting period. Records are expected newest-first. Returns 0 when no waiting
+// period is active.
+func waitingPeriodRemaining(task *config.Task, records []storage.TaskRecord) time.Duration {
+	if task == nil {
+		return 0
+	}
+	wp := task.GetWaitingPeriod()
+	if wp <= 0 {
+		return 0
+	}
+	for _, rec := range records {
+		if rec.Status == storage.ReviewTaskRecord {
+			if elapsed := time.Since(rec.CreatedAt); elapsed < wp {
+				return wp - elapsed
+			}
+			return 0
+		}
+	}
+	return 0
+}
+
+// formatWaitingMessage renders the user-facing waiting period notice.
+func formatWaitingMessage(remaining time.Duration) string {
+	hours := int(remaining.Hours())
+	minutes := int(remaining.Minutes()) % 60
+	return fmt.Sprintf("Waiting period: %dh%dm remaining since last check", hours, minutes)
 }
 
 func AddTaskRecordHandler(w http.ResponseWriter, r *http.Request) {

--- a/templates/partials/lesson_list.html
+++ b/templates/partials/lesson_list.html
@@ -1,8 +1,3 @@
-{{ if and .RegisterMode .WaitingMessage }}
-<p class="text-xs text-orange-400 mb-2">
-  {{.WaitingMessage}}
-</p>
-{{ end }}
 {{if .Lessons}}
 <ul class="space-y-1">
   {{range .Lessons}}

--- a/templates/task.html
+++ b/templates/task.html
@@ -89,6 +89,11 @@
   <div class="text-xs text-gray-500 mb-2">
     // register
   </div>
+  {{ if $.WaitingMessage }}
+  <p class="text-xs text-orange-400 mb-2">
+    {{ $.WaitingMessage }}
+  </p>
+  {{ end }}
   {{ if and (eq .Status "submit") (eq .EntryAuthorID $.SessionUserID) }}
   <form>
     <input type="hidden" name="taskRecordID" value="{{.TaskID}}" />

--- a/tests/run-hurl.sh
+++ b/tests/run-hurl.sh
@@ -134,6 +134,10 @@ run_test tests/ui/user-list-note-column.hurl \
     --variable "student_id=${TIMESTAMP}24" \
     --variable "teacher_id=$TEACHER_ID"
 
+run_test tests/ui/lesson-waiting-period.hurl \
+    --variable "student_id=${TIMESTAMP}25" \
+    --variable "teacher_id=$TEACHER_ID"
+
 # Stop server
 kill "$SERVER_PID" 2>/dev/null
 rm -f "$TEST_DB"

--- a/tests/ui/lesson-waiting-period.hurl
+++ b/tests/ui/lesson-waiting-period.hurl
@@ -92,13 +92,20 @@ content: Second submission right after the review
 
 HTTP 303
 
-# Step 8: Register list shows the waiting-period message and [not yet] marker
-GET {{base_url}}/api/lessons?register=1&task_id={{task_id}}&student_id={{student_id}}
+# Step 8: Task page shows the waiting-period message in the register section
+GET {{base_url}}/user/{{student_id}}/task/{{task_id}}
 Cookie: user_data={{student_token}}
 
 HTTP 200
 [Asserts]
 body contains "Waiting period:"
+
+# Step 8b: Register list shows a [not yet] marker instead of a register button
+GET {{base_url}}/api/lessons?register=1&task_id={{task_id}}&student_id={{student_id}}
+Cookie: user_data={{student_token}}
+
+HTTP 200
+[Asserts]
 body contains "[not yet]"
 body not contains "/api/lesson/{{lesson_id}}/register"
 

--- a/tests/ui/lesson-waiting-period.hurl
+++ b/tests/ui/lesson-waiting-period.hurl
@@ -1,0 +1,114 @@
+# Lesson registration waiting period Test
+# Covers the per-task waiting period (configured in hours; task1 = 24h in the
+# default config). After a teacher review, a student cannot immediately
+# re-register the same task to a lesson:
+#   1. The register list shows the "Waiting period: ..." message and a [not yet]
+#      marker instead of a [register] button.
+#   2. The register POST is rejected with a "waiting period" error.
+#
+# Prerequisites: server running against a fresh DB with default config
+#   (teacher_ids: ["123"], task1 waiting_period_hours: 24).
+# Run: hurl --test \
+#   --variable student_id=$(date +%s) \
+#   --variable teacher_id=123 \
+#   tests/ui/lesson-waiting-period.hurl
+
+# Step 1: Sign in as teacher (signed up by earlier tests)
+POST {{base_url}}/signin
+[Options]
+variable: teacher_password=TeacherPass123!
+variable: student_password=StudentPass123!
+variable: student_username=Waiting Period Student
+variable: task_id=task1
+[FormParams]
+id: {{teacher_id}}
+password: {{teacher_password}}
+
+HTTP 303
+[Captures]
+teacher_token: cookie "user_data"
+
+# Step 2: Teacher creates a lesson
+POST {{base_url}}/api/lessons
+Cookie: user_data={{teacher_token}}
+[Options]
+location: true
+[FormParams]
+date: 2099-12-31
+time: 10:00
+description: Lesson waiting period test
+
+HTTP 200
+[Captures]
+lesson_id: url regex "/lesson/([^/?#]+)"
+
+GET {{base_url}}/logout
+HTTP 303
+
+# Step 3: Sign up student
+POST {{base_url}}/signup
+[FormParams]
+id: {{student_id}}
+password: {{student_password}}
+username: {{student_username}}
+
+HTTP 303
+[Captures]
+student_token: cookie "user_data"
+
+GET {{base_url}}/logout
+HTTP 303
+
+# Step 4: Student submits the task
+POST {{base_url}}/user/{{student_id}}/task/{{task_id}}/journal
+Cookie: user_data={{student_token}}
+[FormParams]
+content: First submission for waiting period test
+
+HTTP 303
+
+# Step 5: Student registers the task to the lesson (no prior review → allowed)
+POST {{base_url}}/api/lesson/{{lesson_id}}/register
+Cookie: user_data={{student_token}}
+[FormParams]
+taskRecordID: {{task_id}}
+studentID: {{student_id}}
+
+HTTP 200
+
+# Step 6: Teacher reviews the student's task just now (starts the waiting period)
+POST {{base_url}}/user/{{student_id}}/task/{{task_id}}/journal
+Cookie: user_data={{teacher_token}}
+[FormParams]
+content: Reviewed — please address the feedback.
+
+HTTP 303
+
+# Step 7: Student resubmits so the latest record is a fresh submission
+POST {{base_url}}/user/{{student_id}}/task/{{task_id}}/journal
+Cookie: user_data={{student_token}}
+[FormParams]
+content: Second submission right after the review
+
+HTTP 303
+
+# Step 8: Register list shows the waiting-period message and [not yet] marker
+GET {{base_url}}/api/lessons?register=1&task_id={{task_id}}&student_id={{student_id}}
+Cookie: user_data={{student_token}}
+
+HTTP 200
+[Asserts]
+body contains "Waiting period:"
+body contains "[not yet]"
+body not contains "/api/lesson/{{lesson_id}}/register"
+
+# Step 9: Attempting to register anyway is rejected by the waiting period
+POST {{base_url}}/api/lesson/{{lesson_id}}/register
+Cookie: user_data={{student_token}}
+[FormParams]
+taskRecordID: {{task_id}}
+studentID: {{student_id}}
+
+HTTP 500
+[Asserts]
+body contains "waiting period"


### PR DESCRIPTION
## Summary

Two related changes to the lesson-registration **waiting period** (the threshold that stops a student re-registering a task too soon after a teacher review):

1. **Configure it in integer hours**, with `0` meaning *no threshold*. Previously the config field was a `*time.Duration` string (`waiting_period`); now it's `waiting_period_hours: <int>` — simpler to author and `0` cleanly disables the check.
2. **Show it on the task page.** While the period is active, the task page's `// register` section displays the remaining time, so a student sees when they can re-register even before the lesson list loads.

## Config behavior

```yaml
tasks:
  - id: "task1"
    waiting_period_hours: 48   # 48h since last review before re-registering
  - id: "task2"
    waiting_period_hours: 0    # no threshold
  - id: "task3"               # key omitted -> 24h default
```

- Absent key → `DefaultWaitingPeriod` (24h).
- `0` → zero duration; both enforcement sites (`RegisterToLesson`, the lesson-list pre-check) already guard on `> 0`, so the check is skipped.
- Negative values are rejected by `LoadConfig`.

## UI behavior

- Task page `// register` section shows a `Waiting period: Xh Ym remaining since last check` banner while active.
- The lesson list keeps its per-lesson `[not yet]` markers (register button suppressed); the duplicate headline was removed from the `lesson_list` partial since it only ever renders on the task page.

## Changes

- `src/config/config.go` — `WaitingPeriodHours *int`, hours→`Duration` conversion, negative-value validation.
- `src/handlers/task.go` — `waitingPeriodRemaining` / `formatWaitingMessage` helpers; `WaitingMessage` on the task view model.
- `src/handlers/lesson.go` — pre-check refactored onto the shared helper.
- `templates/task.html`, `templates/partials/lesson_list.html` — banner added; duplicate headline removed.
- `conf/config.yaml`, `FEATURES.md` — documented.

## Testing

- `src/config/config_test.go` (new) — default / explicit / zero / negative-rejection.
- `tests/ui/lesson-waiting-period.hurl` (new) — end-to-end: after a review the task page shows the waiting message, the lesson list shows `[not yet]`, and the register POST is rejected. Wired into `run-hurl.sh` and the Makefile.
- `go test ./src/...`, `gofmt`, `golangci-lint` (0 issues), `djlint --lint` (0 errors), full hurl suite — all pass.