### PR TITLE
fix: remove dead TaskScores, align CSV score filter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 conf/config-test.yaml
 tmp/*
 slap
+e2e/

--- a/src/handlers/common.go
+++ b/src/handlers/common.go
@@ -23,7 +23,6 @@ type User struct {
 	RegisterMode             bool
 	Tasks                    []config.Task
 	TaskStatuses             map[storage.TaskID]storage.TaskRecordStatus
-	TaskScores               map[storage.TaskID]string
 	Journals                 map[storage.TaskID][]storage.TaskRecord
 	Lessons                  []*storage.Lesson
 	ShowPastLessons          bool

--- a/src/handlers/user.go
+++ b/src/handlers/user.go
@@ -53,7 +53,6 @@ func UserInfoHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	taskStatuses := make(map[storage.TaskID]storage.TaskRecordStatus)
-	taskScores := make(map[storage.TaskID]string)
 	journals := make(map[storage.TaskID][]storage.TaskRecord)
 	for _, task := range AppConfig.Tasks {
 		status, err := DB.LatestTaskStatus(profileUserID, task.ID)
@@ -70,14 +69,6 @@ func UserInfoHandler(w http.ResponseWriter, r *http.Request) {
 			continue
 		}
 		journals[task.ID] = records
-		for _, r := range records {
-			if r.EntryAuthorID != r.StudentID {
-				if score := util.ExtractScore(r.Content); score != "" {
-					taskScores[task.ID] = score
-					break
-				}
-			}
-		}
 	}
 
 	var rulesWithStatus []ScoreRuleWithStatus
@@ -134,7 +125,6 @@ func UserInfoHandler(w http.ResponseWriter, r *http.Request) {
 		IsTeacher:                dbUser.IsTeacher,
 		Tasks:                    AppConfig.Tasks,
 		TaskStatuses:             taskStatuses,
-		TaskScores:               taskScores,
 		Journals:                 journals,
 		Lessons:                  []*storage.Lesson{},
 		ShowPastLessons:          showPast,
@@ -714,12 +704,11 @@ func UserListCSVHandler(w http.ResponseWriter, r *http.Request) {
 			score := ""
 			for _, rec := range records {
 				if rec.EntryAuthorID != rec.StudentID {
-					if s := util.ExtractScore(rec.Content); s != "" {
+					if s := util.ExtractScore(rec.Content); s != "" && s != "0" {
 						score = s
 						break
 					}
 				}
-
 			}
 			row = append(row, score)
 		}


### PR DESCRIPTION
## Summary

- `TaskScores` map was built in `UserInfoHandler` and stored on the `User` struct but never read by any template — score display on the user profile page uses `boldScore` directly on journal content. Removed the dead map and its construction loop.
- CSV export (`/users/csv`) emitted score `"0"` while the users table suppressed it (`ne $td.Score "0"`). Aligned the CSV to match — a score of `"0"` is now omitted in both places.
- Added `e2e/` to `.gitignore` — leftover Playwright scaffold directory with no actual test files.

## Test plan

- [ ] `make test` passes
- [ ] `make format-check lint` passes
- [ ] User profile page still shows scores correctly (unchanged behaviour)
- [ ] CSV export no longer emits `"0"` for tasks where the teacher wrote a `0`-prefixed note