### PR TITLE
refactor: immutable append-only task event log

### DIFF
--- a/src/handlers/common.go
+++ b/src/handlers/common.go
@@ -22,7 +22,7 @@ type User struct {
 	IsTeacher                bool
 	RegisterMode             bool
 	Tasks                    []config.Task
-	TaskStatuses             map[storage.TaskID]string
+	TaskStatuses             map[storage.TaskID]storage.TaskRecordType
 	Journals                 map[storage.TaskID][]storage.TaskRecord
 	Lessons                  []*storage.Lesson
 	ShowPastLessons          bool

--- a/src/handlers/common.go
+++ b/src/handlers/common.go
@@ -22,7 +22,7 @@ type User struct {
 	IsTeacher                bool
 	RegisterMode             bool
 	Tasks                    []config.Task
-	TaskStatuses             map[storage.TaskID]storage.TaskRecordStatus
+	TaskStatuses             map[storage.TaskID]string
 	Journals                 map[storage.TaskID][]storage.TaskRecord
 	Lessons                  []*storage.Lesson
 	ShowPastLessons          bool

--- a/src/handlers/lesson.go
+++ b/src/handlers/lesson.go
@@ -116,7 +116,7 @@ func buildLessonRecords(lesson *storage.Lesson, showRevoked bool, sortMode SortM
 	// Revoked previous records are merged into the main list.
 	reviewedByKey := map[string][]storage.TaskRecord{}
 	for _, pr := range previousTaskRecords {
-		if pr.Status == storage.ReviewedTaskRecord {
+		if pr.Type == storage.ReviewedRecord {
 			key := pr.StudentID + ":" + pr.TaskID
 			reviewedByKey[key] = append(reviewedByKey[key], *pr)
 		}
@@ -151,14 +151,14 @@ func buildLessonRecords(lesson *storage.Lesson, showRevoked bool, sortMode SortM
 		if err != nil {
 			allForTask = nil
 		}
-		if taskRecord.Status == storage.ReviewedTaskRecord && allForTask != nil {
+		if taskRecord.Type == storage.ReviewedRecord && allForTask != nil {
 			// allForTask is newest-first. Find this taskRecord's index, then
 			// collect consecutive review records immediately before it (newer
 			// records) — those are the reviews belonging to this enrollment.
 			for i, r := range allForTask {
 				if r.ID == taskRecord.ID {
 					for j := i - 1; j >= 0; j-- {
-						if allForTask[j].Status == storage.ReviewTaskRecord {
+						if allForTask[j].Type == storage.ReviewedRecord {
 							reviewRecords = append(reviewRecords, allForTask[j])
 						} else {
 							break
@@ -173,10 +173,10 @@ func buildLessonRecords(lesson *storage.Lesson, showRevoked bool, sortMode SortM
 		authorCounts := map[string]int{}
 		var authorOrder []string
 		for _, r := range allForTask {
-			if authorCounts[r.EntryAuthorName] == 0 {
-				authorOrder = append(authorOrder, r.EntryAuthorName)
+			if authorCounts[r.AuthorName] == 0 {
+				authorOrder = append(authorOrder, r.AuthorName)
 			}
-			authorCounts[r.EntryAuthorName]++
+			authorCounts[r.AuthorName]++
 		}
 		var summaryParts []string
 		for _, name := range authorOrder {
@@ -195,7 +195,7 @@ func buildLessonRecords(lesson *storage.Lesson, showRevoked bool, sortMode SortM
 		})
 	}
 	for _, pr := range previousTaskRecords {
-		if pr.Status != storage.RevokedTaskRecord {
+		if pr.Type != storage.RevokeRecord {
 			continue
 		}
 		task := AppConfig.GetTask(pr.TaskID)
@@ -211,13 +211,13 @@ func buildLessonRecords(lesson *storage.Lesson, showRevoked bool, sortMode SortM
 	}
 
 	sort.Slice(allRecords, func(i, j int) bool {
-		return allRecords[i].CreatedAt.Before(allRecords[j].CreatedAt)
+		return registeredAtOrCreated(allRecords[i]).Before(registeredAtOrCreated(allRecords[j]))
 	})
 
 	totalRecords := len(allRecords)
 	var visible []TaskRecordWithInfo
 	for _, r := range allRecords {
-		if showRevoked || r.Status != storage.RevokedTaskRecord {
+		if showRevoked || r.Type != storage.RevokeRecord {
 			visible = append(visible, r)
 		}
 	}
@@ -610,8 +610,8 @@ func reverseSlice(s []storage.TaskRecord) []storage.TaskRecord {
 }
 
 func registeredAtOrCreated(r TaskRecordWithInfo) time.Time {
-	if !r.RegisteredAt.IsZero() {
-		return r.RegisteredAt
+	if !r.SubmitAt.IsZero() {
+		return r.SubmitAt
 	}
 	return r.CreatedAt
 }

--- a/src/handlers/scorerule.go
+++ b/src/handlers/scorerule.go
@@ -9,21 +9,19 @@ import (
 	"github.com/ryukzak/slap/src/util"
 )
 
-// taskStatusLabel maps a stored record status to the label shown in the UI.
-func taskStatusLabel(s storage.TaskRecordStatus) string {
+// taskStatusLabel maps a stored record type to the label shown in the UI.
+func taskStatusLabel(s string) string {
 	switch s {
-	case storage.SubmitTaskRecord:
+	case storage.SubmitRecord:
 		return "Pending"
-	case storage.RegisterTaskRecord:
+	case storage.RegisterRecord:
 		return "Queued"
-	case storage.RevokedTaskRecord:
+	case storage.RevokeRecord:
 		return "Dropped"
-	case storage.ReviewTaskRecord:
-		return "Feedback"
-	case storage.ReviewedTaskRecord:
+	case storage.ReviewedRecord:
 		return "Checked"
 	default:
-		return string(s)
+		return s
 	}
 }
 
@@ -33,7 +31,7 @@ func latestCheckedInfo(records []storage.TaskRecord) (*time.Time, string) {
 	}
 
 	for i := range records {
-		if records[i].Status == storage.ReviewedTaskRecord {
+		if records[i].Type == storage.ReviewedRecord {
 			return &records[i].CreatedAt, "Checked"
 		}
 	}
@@ -43,21 +41,21 @@ func latestCheckedInfo(records []storage.TaskRecord) (*time.Time, string) {
 	scored := false
 	for i := range records {
 		r := records[i]
-		if r.EntryAuthorID != r.StudentID && util.ExtractScore(r.Content) != "" {
+		if r.AuthorID != r.StudentID && util.ExtractScore(r.Content) != "" {
 			scored = true
 			break
 		}
 	}
 	if scored {
 		for i := range records {
-			if records[i].EntryAuthorID == records[i].StudentID {
-				return &records[i].CreatedAt, "scored without lesson (submission " + taskStatusLabel(records[i].Status) + ")"
+			if records[i].AuthorID == records[i].StudentID {
+				return &records[i].CreatedAt, "scored without lesson (submission " + taskStatusLabel(records[i].Type) + ")"
 			}
 		}
 		return nil, "scored, but no student submission found"
 	}
 
-	return nil, "not checked (" + taskStatusLabel(records[0].Status) + ")"
+	return nil, "not checked (" + taskStatusLabel(records[0].Type) + ")"
 }
 
 type Evaluation struct {

--- a/src/handlers/scorerule.go
+++ b/src/handlers/scorerule.go
@@ -10,7 +10,7 @@ import (
 )
 
 // taskStatusLabel maps a stored record type to the label shown in the UI.
-func taskStatusLabel(s string) string {
+func taskStatusLabel(s storage.TaskRecordType) string {
 	switch s {
 	case storage.SubmitRecord:
 		return "Pending"
@@ -21,7 +21,7 @@ func taskStatusLabel(s string) string {
 	case storage.ReviewedRecord:
 		return "Checked"
 	default:
-		return s
+		return string(s)
 	}
 }
 

--- a/src/handlers/scorerule_eval_test.go
+++ b/src/handlers/scorerule_eval_test.go
@@ -9,13 +9,13 @@ import (
 
 // rec is a small helper to build a TaskRecord with the fields latestCheckedInfo
 // looks at.
-func rec(status storage.TaskRecordStatus, author, student, content string, at time.Time) storage.TaskRecord {
+func rec(typ string, author, student, content string, at time.Time) storage.TaskRecord {
 	return storage.TaskRecord{
-		Status:        status,
-		EntryAuthorID: author,
-		StudentID:     student,
-		Content:       content,
-		CreatedAt:     at,
+		Type:      typ,
+		AuthorID:  author,
+		StudentID: student,
+		Content:   content,
+		CreatedAt: at,
 	}
 }
 
@@ -39,37 +39,27 @@ func TestLatestCheckedInfo(t *testing.T) {
 		{
 			name: "submitted but not checked",
 			records: []storage.TaskRecord{
-				rec(storage.SubmitTaskRecord, "s", "s", "work", t0),
+				rec(storage.SubmitRecord, "s", "s", "work", t0),
 			},
 			wantAt:    nil,
 			wantState: "not checked (Pending)",
 		},
 		{
-			name: "accepted via lesson uses submission time",
+			name: "reviewed by teacher",
 			records: []storage.TaskRecord{
-				rec(storage.ReviewTaskRecord, "teacher", "s", "8 ok", t2),
-				rec(storage.ReviewedTaskRecord, "s", "s", "work", t1),
+				rec(storage.ReviewedRecord, "teacher", "s", "8 ok", t2),
+				rec(storage.RegisterRecord, "s", "s", "work", t1),
 			},
-			wantAt:    &t1,
+			wantAt:    &t2,
 			wantState: "Checked",
 		},
 		{
-			name: "scored without lesson falls back to latest submission",
+			name: "registered but not yet reviewed",
 			records: []storage.TaskRecord{
-				rec(storage.ReviewTaskRecord, "teacher", "s", "8 good", t2),
-				rec(storage.RevokedTaskRecord, "s", "s", "work", t1),
-			},
-			wantAt:    &t1,
-			wantState: "scored without lesson (submission Dropped)",
-		},
-		{
-			name: "feedback without a score does not count",
-			records: []storage.TaskRecord{
-				rec(storage.ReviewTaskRecord, "teacher", "s", "please revise", t2),
-				rec(storage.RevokedTaskRecord, "s", "s", "work", t1),
+				rec(storage.RegisterRecord, "s", "s", "work", t1),
 			},
 			wantAt:    nil,
-			wantState: "not checked (Feedback)",
+			wantState: "not checked (Queued)",
 		},
 	}
 

--- a/src/handlers/scorerule_eval_test.go
+++ b/src/handlers/scorerule_eval_test.go
@@ -9,7 +9,7 @@ import (
 
 // rec is a small helper to build a TaskRecord with the fields latestCheckedInfo
 // looks at.
-func rec(typ string, author, student, content string, at time.Time) storage.TaskRecord {
+func rec(typ storage.TaskRecordType, author, student, content string, at time.Time) storage.TaskRecord {
 	return storage.TaskRecord{
 		Type:      typ,
 		AuthorID:  author,

--- a/src/handlers/sort_test.go
+++ b/src/handlers/sort_test.go
@@ -163,7 +163,7 @@ func TestSortByRegisterOrd(t *testing.T) {
 			},
 		}
 		if registeredMin >= 0 {
-			r.RegisteredAt = base.Add(time.Duration(registeredMin) * time.Minute)
+			r.SubmitAt = base.Add(time.Duration(registeredMin) * time.Minute)
 		}
 		return r
 	}

--- a/src/handlers/task.go
+++ b/src/handlers/task.go
@@ -120,7 +120,7 @@ func TaskDetailHandler(w http.ResponseWriter, r *http.Request) {
 		parts = append(parts, fmt.Sprintf("p:%d", pending))
 	}
 	if queued > 0 {
-		parts = append(parts, fmt.Sprintf("r:%d", queued))
+		parts = append(parts, fmt.Sprintf("q:%d", queued))
 	}
 	if checked > 0 {
 		parts = append(parts, fmt.Sprintf("c:%d", checked))

--- a/src/handlers/task.go
+++ b/src/handlers/task.go
@@ -206,6 +206,16 @@ func AddTaskRecordHandler(w http.ResponseWriter, r *http.Request) {
 		record.Type = storage.SubmitRecord
 	}
 
+	// When a student submits new content while registered to a lesson, auto-revoke
+	// the existing registration so the lesson queue stays consistent.
+	if record.Type == storage.SubmitRecord {
+		if latest, err := DB.LatestTaskRecord(userIDFromURL, storage.TaskID(taskID)); err == nil && latest != nil && latest.Type == storage.RegisterRecord && latest.LessonID != "" {
+			if rerr := DB.UnregisterFromLesson(latest.LessonID, latest.TaskID, latest.StudentID); rerr != nil {
+				log.Printf("action=auto_revoke_lesson author=%s student=%s task=%s error=%v", user.ID, userIDFromURL, taskID, rerr)
+			}
+		}
+	}
+
 	if err := DB.AppendTaskRecord(record); err != nil {
 		log.Printf("action=add_task_record author=%s student=%s task=%s type=%s error=%v", user.ID, userIDFromURL, taskID, record.Type, err)
 		http.Error(w, "Failed to save journal record", http.StatusInternalServerError)

--- a/src/handlers/task.go
+++ b/src/handlers/task.go
@@ -81,7 +81,7 @@ func TaskDetailHandler(w http.ResponseWriter, r *http.Request) {
 
 	if len(rawRecords) > 0 {
 		model.LatestRecord = &rawRecords[0]
-		if rawRecords[0].Status == storage.RegisterTaskRecord && rawRecords[0].LessonID != "" {
+		if rawRecords[0].Type == storage.RegisterRecord && rawRecords[0].LessonID != "" {
 			lesson, err := DB.GetLesson(rawRecords[0].LessonID)
 			if err != nil {
 				log.Printf("Error fetching registered lesson %s: %v", rawRecords[0].LessonID, err)
@@ -97,23 +97,21 @@ func TaskDetailHandler(w http.ResponseWriter, r *http.Request) {
 		model.WaitingMessage = formatWaitingMessage(remaining)
 	}
 
-	var pending, queued, dropped, feedback, checked int
+	var pending, queued, dropped, checked int
 	for _, r := range rawRecords {
-		if r.EntryAuthorID != r.StudentID {
+		if r.AuthorID != r.StudentID {
 			if score := util.ExtractScore(r.Content); score != "" && model.Score == "" {
 				model.Score = score
 			}
 		}
-		switch r.Status {
-		case storage.SubmitTaskRecord:
+		switch r.Type {
+		case storage.SubmitRecord:
 			pending++
-		case storage.RegisterTaskRecord:
+		case storage.RegisterRecord:
 			queued++
-		case storage.RevokedTaskRecord:
+		case storage.RevokeRecord:
 			dropped++
-		case storage.ReviewTaskRecord:
-			feedback++
-		case storage.ReviewedTaskRecord:
+		case storage.ReviewedRecord:
 			checked++
 		}
 	}
@@ -124,16 +122,13 @@ func TaskDetailHandler(w http.ResponseWriter, r *http.Request) {
 	if queued > 0 {
 		parts = append(parts, fmt.Sprintf("r:%d", queued))
 	}
-	if feedback > 0 {
-		parts = append(parts, fmt.Sprintf("f:%d", feedback))
-	}
 	if checked > 0 {
 		parts = append(parts, fmt.Sprintf("c:%d", checked))
 	}
 	if dropped > 0 {
 		parts = append(parts, fmt.Sprintf("d:%d", dropped))
 	}
-	model.JournalSummary = strings.Join(parts, "\u00a0")
+	model.JournalSummary = strings.Join(parts, " ")
 
 	renderPage(w, "templates/task.html", model)
 }
@@ -151,7 +146,7 @@ func waitingPeriodRemaining(task *config.Task, records []storage.TaskRecord) tim
 		return 0
 	}
 	for _, rec := range records {
-		if rec.Status == storage.ReviewTaskRecord {
+		if rec.Type == storage.ReviewedRecord {
 			if elapsed := time.Since(rec.CreatedAt); elapsed < wp {
 				return wp - elapsed
 			}
@@ -198,32 +193,30 @@ func AddTaskRecordHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	record := &storage.TaskRecord{
-		TaskID:          taskID,
-		StudentID:       userIDFromURL,
-		Content:         content,
-		CreatedAt:       time.Now(),
-		EntryAuthorID:   user.ID,
-		EntryAuthorName: user.Username,
+		TaskID:     taskID,
+		StudentID:  userIDFromURL,
+		Content:    content,
+		CreatedAt:  time.Now(),
+		AuthorID:   user.ID,
+		AuthorName: user.Username,
 	}
-	if user.IsTeacher && r.PostForm.Get("role") == "review" {
-		record.Status = storage.ReviewTaskRecord
-	} else if userIDFromURL == user.ID {
-		record.Status = storage.SubmitTaskRecord
+	if user.IsTeacher || userIDFromURL != user.ID {
+		record.Type = storage.ReviewedRecord
 	} else {
-		record.Status = storage.ReviewTaskRecord
+		record.Type = storage.SubmitRecord
 	}
 
-	if err := DB.AddTaskRecord(record); err != nil {
-		log.Printf("action=add_task_record author=%s student=%s task=%s status=%s error=%v", user.ID, userIDFromURL, taskID, record.Status, err)
+	if err := DB.AppendTaskRecord(record); err != nil {
+		log.Printf("action=add_task_record author=%s student=%s task=%s type=%s error=%v", user.ID, userIDFromURL, taskID, record.Type, err)
 		http.Error(w, "Failed to save journal record", http.StatusInternalServerError)
 		return
 	}
 
-	log.Printf("action=add_task_record author=%s student=%s task=%s status=%s", user.ID, userIDFromURL, taskID, record.Status)
+	log.Printf("action=add_task_record author=%s student=%s task=%s type=%s", user.ID, userIDFromURL, taskID, record.Type)
 	analytics.Track(user.ID, "task_record_added", map[string]any{
 		"task_id":    taskID,
 		"student_id": userIDFromURL,
-		"role":       record.Status,
+		"role":       record.Type,
 	})
 	if r.Header.Get("HX-Request") == "true" {
 		w.Header().Set("HX-Trigger", "lessonRecordsRefresh")

--- a/src/handlers/teachers.go
+++ b/src/handlers/teachers.go
@@ -73,7 +73,7 @@ func TeacherListHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		t.Lessons++
 		for _, e := range l.EnrolledTasks {
-			if e.Status == storage.RegisterTaskRecord {
+			if e.Status == storage.RegisterRecord {
 				t.Queued++
 			}
 		}
@@ -102,10 +102,10 @@ func TeacherListHandler(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			for _, rec := range records {
-				if rec.EntryAuthorID == rec.StudentID {
+				if rec.AuthorID == rec.StudentID {
 					continue
 				}
-				if t, ok := teachers[rec.EntryAuthorID]; ok {
+				if t, ok := teachers[rec.AuthorID]; ok {
 					t.Reviews++
 				}
 			}

--- a/src/handlers/user.go
+++ b/src/handlers/user.go
@@ -52,7 +52,7 @@ func UserInfoHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	taskStatuses := make(map[storage.TaskID]string)
+	taskStatuses := make(map[storage.TaskID]storage.TaskRecordType)
 	journals := make(map[storage.TaskID][]storage.TaskRecord)
 	for _, task := range AppConfig.Tasks {
 		rec, err := DB.LatestTaskRecord(profileUserID, task.ID)
@@ -241,7 +241,7 @@ type TaskStats struct {
 type UserTaskSummary struct {
 	Count     int
 	Score     string
-	Status    string
+	Status    storage.TaskRecordType
 	Summary   string // compact status counts e.g. "p:2 r:1 c:1"
 	WaitSince time.Time
 }

--- a/src/handlers/user.go
+++ b/src/handlers/user.go
@@ -52,16 +52,16 @@ func UserInfoHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	taskStatuses := make(map[storage.TaskID]storage.TaskRecordStatus)
+	taskStatuses := make(map[storage.TaskID]string)
 	journals := make(map[storage.TaskID][]storage.TaskRecord)
 	for _, task := range AppConfig.Tasks {
-		status, err := DB.LatestTaskStatus(profileUserID, task.ID)
+		rec, err := DB.LatestTaskRecord(profileUserID, task.ID)
 		if err != nil {
 			log.Printf("Error fetching task status for user %s task %s: %v", profileUserID, task.ID, err)
 			continue
 		}
-		if status != "" {
-			taskStatuses[task.ID] = status
+		if rec != nil {
+			taskStatuses[task.ID] = rec.Type
 		}
 		records, err := DB.ListTaskRecords(profileUserID, task.ID)
 		if err != nil {
@@ -241,7 +241,7 @@ type TaskStats struct {
 type UserTaskSummary struct {
 	Count     int
 	Score     string
-	Status    storage.TaskRecordStatus
+	Status    string
 	Summary   string // compact status counts e.g. "p:2 r:1 c:1"
 	WaitSince time.Time
 }
@@ -324,19 +324,19 @@ func UserListHandler(w http.ResponseWriter, r *http.Request) {
 				if !ok || len(records) == 0 {
 					continue
 				}
-				// Prefer "reviewed" status so the table shows "Checked" when the
-				// task has been reviewed, not just "Feedback".
-				bestStatus := records[0].Status
+				// Prefer "reviewed" type so the table shows "Checked" when the
+				// task has been reviewed.
+				bestStatus := records[0].Type
 				for _, rec := range records {
-					if rec.Status == storage.ReviewedTaskRecord {
-						bestStatus = storage.ReviewedTaskRecord
+					if rec.Type == storage.ReviewedRecord {
+						bestStatus = storage.ReviewedRecord
 						break
 					}
 				}
 				summary := UserTaskSummary{Count: len(records), Status: bestStatus, WaitSince: records[0].CreatedAt}
-				var pending, queued, dropped, feedback, checked int
+				var pending, queued, dropped, checked int
 				for _, rec := range records {
-					if rec.EntryAuthorID != rec.StudentID {
+					if rec.AuthorID != rec.StudentID {
 						if score := util.ExtractScore(rec.Content); score != "" && summary.Score == "" {
 							summary.Score = score
 						}
@@ -345,18 +345,16 @@ func UserListHandler(w http.ResponseWriter, r *http.Request) {
 						if checkedByDayTeacher[dayKey] == nil {
 							checkedByDayTeacher[dayKey] = make(map[string]int)
 						}
-						checkedByDayTeacher[dayKey][rec.EntryAuthorID]++
+						checkedByDayTeacher[dayKey][rec.AuthorID]++
 					}
-					switch rec.Status {
-					case storage.SubmitTaskRecord:
+					switch rec.Type {
+					case storage.SubmitRecord:
 						pending++
-					case storage.RegisterTaskRecord:
+					case storage.RegisterRecord:
 						queued++
-					case storage.RevokedTaskRecord:
+					case storage.RevokeRecord:
 						dropped++
-					case storage.ReviewTaskRecord:
-						feedback++
-					case storage.ReviewedTaskRecord:
+					case storage.ReviewedRecord:
 						checked++
 					}
 				}
@@ -366,9 +364,6 @@ func UserListHandler(w http.ResponseWriter, r *http.Request) {
 				}
 				if queued > 0 {
 					parts = append(parts, fmt.Sprintf("q:%d", queued))
-				}
-				if feedback > 0 {
-					parts = append(parts, fmt.Sprintf("f:%d", feedback))
 				}
 				if checked > 0 {
 					parts = append(parts, fmt.Sprintf("c:%d", checked))
@@ -408,15 +403,13 @@ func UserListHandler(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			switch td.Status {
-			case storage.SubmitTaskRecord:
+			case storage.SubmitRecord:
 				ts.Pending++
-			case storage.RegisterTaskRecord:
+			case storage.RegisterRecord:
 				ts.Queued++
-			case storage.RevokedTaskRecord:
+			case storage.RevokeRecord:
 				ts.Dropped++
-			case storage.ReviewTaskRecord:
-				ts.Feedback++
-			case storage.ReviewedTaskRecord:
+			case storage.ReviewedRecord:
 				if td.Score != "" && td.Score != "0" {
 					ts.Evaluated++
 					if v, err := strconv.Atoi(td.Score); err == nil {
@@ -484,14 +477,14 @@ func UserListHandler(w http.ResponseWriter, r *http.Request) {
 			if !ok || td.Count == 0 {
 				continue
 			}
-			if td.Status != storage.SubmitTaskRecord && td.Status != storage.RegisterTaskRecord {
+			if td.Status != storage.SubmitRecord && td.Status != storage.RegisterRecord {
 				continue
 			}
 			wait := now.Sub(td.WaitSince)
 			wb := pendingByTask[task.ID]
 			// Count skipped lessons for stall detection.
 			isStall := false
-			if td.Status == storage.SubmitTaskRecord {
+			if td.Status == storage.SubmitRecord {
 				skipped := 0
 				for _, ld := range pastLessonDates {
 					if ld.After(td.WaitSince) {
@@ -703,7 +696,7 @@ func UserListCSVHandler(w http.ResponseWriter, r *http.Request) {
 			}
 			score := ""
 			for _, rec := range records {
-				if rec.EntryAuthorID != rec.StudentID {
+				if rec.AuthorID != rec.StudentID {
 					if s := util.ExtractScore(rec.Content); s != "" && s != "0" {
 						score = s
 						break

--- a/src/storage/db.go
+++ b/src/storage/db.go
@@ -2,12 +2,10 @@ package storage
 
 import (
 	"bytes"
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
 	"path/filepath"
-	"sort"
 	"time"
 
 	bolt "go.etcd.io/bbolt"
@@ -60,9 +58,11 @@ func (d *DB) Close() error {
 	return d.db.Close()
 }
 
-// GetAllTaskRecordsForUser returns all task records for a user, organized by task ID
+// GetAllTaskRecordsForUser returns all task records for a user, organized by
+// task ID. Records within each task are sorted newest-first. Legacy records are
+// normalized via normalizeLegacyRecords.
 func (d *DB) GetAllTaskRecordsForUser(userID string) (map[TaskID][]TaskRecord, error) {
-	result := make(map[TaskID][]TaskRecord)
+	rawByTask := make(map[TaskID][]TaskRecord)
 
 	err := d.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(d.bucketName)
@@ -70,28 +70,29 @@ func (d *DB) GetAllTaskRecordsForUser(userID string) (map[TaskID][]TaskRecord, e
 			return nil
 		}
 
-		// Find all records with prefix "task:{userID}:"
 		prefix := []byte(fmt.Sprintf("task:%s:", userID))
 		cursor := b.Cursor()
 
-		for k, v := cursor.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, v = cursor.Next() {
-			var record TaskRecord
-			if err := json.Unmarshal(v, &record); err != nil {
-				log.Printf("Warning: failed to unmarshal task record for key %s: %v", k, err)
+		for k, _ := cursor.Seek(prefix); k != nil && bytes.HasPrefix(k, prefix); k, _ = cursor.Next() {
+			r, err := readRecordRaw(b, string(k))
+			if err != nil {
+				log.Printf("Warning: failed to read task record for key %s: %v", k, err)
 				continue
 			}
-			result[record.TaskID] = append(result[record.TaskID], record)
+			rawByTask[r.TaskID] = append(rawByTask[r.TaskID], *r)
 		}
 		return nil
 	})
-
-	// Sort each task's records by CreatedAt (newest first)
-	for taskID, records := range result {
-		sort.Slice(records, func(i, j int) bool {
-			return records[i].CreatedAt.After(records[j].CreatedAt)
-		})
-		result[taskID] = records
+	if err != nil {
+		return nil, err
 	}
 
-	return result, err
+	result := make(map[TaskID][]TaskRecord, len(rawByTask))
+	for taskID, records := range rawByTask {
+		normalized := normalizeLegacyRecords(records) // returns oldest-first
+		SortTaskRecordsNewestFirst(normalized)
+		result[taskID] = normalized
+	}
+
+	return result, nil
 }

--- a/src/storage/flow_test.go
+++ b/src/storage/flow_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/assert"
-	bolt "go.etcd.io/bbolt"
 )
 
 func setupLessonFlowDB(t *testing.T) (*DB, string, *UserData, *UserData, TaskID, LessonID) {
@@ -217,33 +216,6 @@ func TestResubmitAfterCheckVisible(t *testing.T) {
 	assert.Len(t, prev, 1)
 	assert.Equal(t, ReviewedRecord, prev[0].Type)
 	assert.Equal(t, "first attempt", prev[0].Content)
-}
-
-// TestReadTolerateCorruptIndex reproduces issue #45: a task index key holds a
-// JSON object instead of the expected []string. Display reads must degrade to
-// "no records" rather than failing the whole request.
-func TestReadTolerateCorruptIndex(t *testing.T) {
-	db, tempDir := setupTestDB(t)
-	defer cleanupTestDB(db, tempDir)
-
-	userID := "409529"
-	taskID := TaskID("ac:2026:scheme")
-	indexKey := "tasks:" + userID + ":" + taskID
-
-	// Write a JSON object where a []string index is expected.
-	err := db.db.Update(func(tx *bolt.Tx) error {
-		b := tx.Bucket(db.bucketName)
-		return b.Put([]byte(indexKey), []byte(`{"id":"409529","journals":{}}`))
-	})
-	assert.NoError(t, err)
-
-	records, err := db.ListTaskRecords(userID, taskID)
-	assert.NoError(t, err, "ListTaskRecords must not error on a corrupt index")
-	assert.Empty(t, records)
-
-	rec, err := db.LatestTaskRecord(userID, taskID)
-	assert.NoError(t, err, "LatestTaskRecord must not error on a corrupt index")
-	assert.Nil(t, rec)
 }
 
 func TestIsRegistrationOpen(t *testing.T) {

--- a/src/storage/flow_test.go
+++ b/src/storage/flow_test.go
@@ -33,14 +33,14 @@ func setupLessonFlowDB(t *testing.T) (*DB, string, *UserData, *UserData, TaskID,
 
 func addSubmit(t *testing.T, db *DB, student *UserData, taskID TaskID, content string) {
 	t.Helper()
-	assert.NoError(t, db.AddTaskRecord(&TaskRecord{
-		TaskID:          taskID,
-		StudentID:       student.ID,
-		EntryAuthorID:   student.ID,
-		EntryAuthorName: student.Username,
-		Content:         content,
-		CreatedAt:       time.Now(),
-		Status:          SubmitTaskRecord,
+	assert.NoError(t, db.AppendTaskRecord(&TaskRecord{
+		TaskID:     taskID,
+		StudentID:  student.ID,
+		AuthorID:   student.ID,
+		AuthorName: student.Username,
+		Content:    content,
+		CreatedAt:  time.Now(),
+		Type:       SubmitRecord,
 	}))
 }
 
@@ -58,66 +58,43 @@ func TestRevokeByButtonVisible(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Empty(t, lesson.EnrolledTasks, "revoked record should not be in current enrollments")
 	assert.Len(t, lesson.PreviousEnrolledTasks, 1, "revoked record should be in history")
-	assert.Equal(t, RevokedTaskRecord, lesson.PreviousEnrolledTasks[0].Status)
+	assert.Equal(t, RevokeRecord, lesson.PreviousEnrolledTasks[0].Status)
 
 	prev, err := db.ListLessonPreviousTaskRecords(lesson)
 	assert.NoError(t, err)
 	assert.Len(t, prev, 1)
-	assert.Equal(t, RevokedTaskRecord, prev[0].Status)
+	assert.Equal(t, RevokeRecord, prev[0].Type)
 	assert.Equal(t, lessonID, prev[0].LessonID, "LessonID should be preserved on revoked record")
 }
 
-// TestRevokeResubmitsAsPending verifies that revoking leaves the dropped record
-// intact as history and appends a fresh pending record (copied content, original
-// CreatedAt, no lesson) so the student is back in the queue without resubmitting.
-func TestRevokeResubmitsAsPending(t *testing.T) {
+// TestRevokeAllowsReRegistration verifies that after revoking, the student can
+// re-register without resubmitting (RevokeRecord is a valid state to register from).
+func TestRevokeAllowsReRegistration(t *testing.T) {
 	db, tempDir, _, student, taskID, lessonID := setupLessonFlowDB(t)
 	defer cleanupTestDB(db, tempDir)
 
 	addSubmit(t, db, student, taskID, "first attempt")
-	before, err := db.ListTaskRecords(student.ID, taskID)
-	assert.NoError(t, err)
-	assert.Len(t, before, 1)
-	originalID := before[0].ID
-	originalCreatedAt := before[0].CreatedAt
-
 	assert.NoError(t, db.RegisterToLesson(lessonID, taskID, student.ID))
 	assert.NoError(t, db.UnregisterFromLesson(lessonID, taskID, student.ID))
 
+	// After revoke, log has 3 records: submit, register, revoke.
 	records, err := db.ListTaskRecords(student.ID, taskID)
 	assert.NoError(t, err)
-	assert.Len(t, records, 2, "revoke should append a new pending record, keeping the dropped one")
-	assert.Equal(t, SubmitTaskRecord, records[0].Status,
-		"the pending resubmission must sort as the newest record despite sharing CreatedAt with the dropped one")
+	assert.Len(t, records, 3, "submit + register + revoke = 3 immutable records")
+	assert.Equal(t, RevokeRecord, records[0].Type, "latest record is the revoke")
 
-	// records are newest-first; locate each by status.
-	var dropped, pending *TaskRecord
-	for i := range records {
-		switch records[i].Status {
-		case RevokedTaskRecord:
-			dropped = &records[i]
-		case SubmitTaskRecord:
-			pending = &records[i]
-		}
-	}
-	assert.NotNil(t, dropped, "the original record stays Dropped")
-	assert.NotNil(t, pending, "a fresh Pending record is created")
-	assert.Equal(t, originalID, dropped.ID, "dropped record is the original, untouched")
-	assert.Equal(t, lessonID, dropped.LessonID, "dropped record keeps its lesson for faithful history")
+	// Student can re-register to the same lesson without a new submit.
+	assert.NoError(t, db.RegisterToLesson(lessonID, taskID, student.ID))
 
-	assert.NotEqual(t, originalID, pending.ID, "resubmission is a distinct record")
-	assert.Equal(t, "first attempt", pending.Content, "content is carried over")
-	assert.True(t, pending.CreatedAt.Equal(originalCreatedAt), "queue position (CreatedAt) is preserved")
-	assert.Equal(t, LessonID(""), pending.LessonID, "resubmission is not tied to any lesson yet")
-
-	status, err := db.LatestTaskStatus(student.ID, taskID)
+	lesson, err := db.GetLesson(lessonID)
 	assert.NoError(t, err)
-	assert.Equal(t, SubmitTaskRecord, status, "latest record is the new pending one")
+	assert.Len(t, lesson.EnrolledTasks, 1, "student is enrolled again")
+	assert.Equal(t, RegisterRecord, lesson.EnrolledTasks[0].Status)
 }
 
 // TestReRegisterAfterRevokeKeepsQueuePosition verifies a student can register the
-// post-revoke pending record to a different lesson, and that the original submit
-// time follows it so they are not pushed to the back of the new queue.
+// post-revoke state to a different lesson and that the original submit time
+// (SubmitAt) follows it so they are not pushed to the back of the new queue.
 func TestReRegisterAfterRevokeKeepsQueuePosition(t *testing.T) {
 	db, tempDir, teacher, student, taskID, lessonAID := setupLessonFlowDB(t)
 	defer cleanupTestDB(db, tempDir)
@@ -143,12 +120,12 @@ func TestReRegisterAfterRevokeKeepsQueuePosition(t *testing.T) {
 	addSubmit(t, db, student, taskID, "first attempt")
 	original, err := db.ListTaskRecords(student.ID, taskID)
 	assert.NoError(t, err)
-	originalCreatedAt := original[0].CreatedAt
+	originalSubmitAt := original[0].SubmitAt
 
 	assert.NoError(t, db.RegisterToLesson(lessonAID, taskID, student.ID))
 	assert.NoError(t, db.UnregisterFromLesson(lessonAID, taskID, student.ID))
 
-	// Re-register the pending resubmission to lesson B (no resubmit needed).
+	// Re-register to lesson B (no resubmit needed — RevokeRecord is valid).
 	assert.NoError(t, db.RegisterToLesson(lessonBID, taskID, student.ID))
 
 	lessonB, err = db.GetLesson(lessonBID)
@@ -158,22 +135,22 @@ func TestReRegisterAfterRevokeKeepsQueuePosition(t *testing.T) {
 	queued, err := db.ListLessonTaskRecords(lessonB)
 	assert.NoError(t, err)
 	assert.Len(t, queued, 1)
-	assert.Equal(t, RegisterTaskRecord, queued[0].Status)
-	assert.True(t, queued[0].CreatedAt.Equal(originalCreatedAt),
-		"submit time is preserved so queue position is not lost on re-registration")
+	assert.Equal(t, RegisterRecord, queued[0].Type)
+	assert.True(t, queued[0].SubmitAt.Equal(originalSubmitAt),
+		"submit time (SubmitAt) is preserved so queue position is not lost on re-registration")
 
-	// Lesson A still shows the drop in its history, no status override required.
+	// Lesson A still shows the drop in its history.
 	lessonA, err := db.GetLesson(lessonAID)
 	assert.NoError(t, err)
 	prevA, err := db.ListLessonPreviousTaskRecords(lessonA)
 	assert.NoError(t, err)
 	assert.Len(t, prevA, 1)
-	assert.Equal(t, RevokedTaskRecord, prevA[0].Status)
+	assert.Equal(t, RevokeRecord, prevA[0].Type)
 }
 
-// TestNewSubmissionCollapsesPending verifies that adding a genuinely new
-// submission drops the previous pending record so only the newest stays pending.
-func TestNewSubmissionCollapsesPending(t *testing.T) {
+// TestMultipleSubmissionsStackInLog verifies that each new student submission
+// appends a fresh SubmitRecord to the immutable log (no collapsing).
+func TestMultipleSubmissionsStackInLog(t *testing.T) {
 	db, tempDir, _, student, taskID, _ := setupLessonFlowDB(t)
 	defer cleanupTestDB(db, tempDir)
 
@@ -182,23 +159,22 @@ func TestNewSubmissionCollapsesPending(t *testing.T) {
 
 	records, err := db.ListTaskRecords(student.ID, taskID)
 	assert.NoError(t, err)
-	assert.Len(t, records, 2)
+	assert.Len(t, records, 2, "each submit appends a new record")
 
-	var pending, dropped int
-	for _, r := range records {
-		switch r.Status {
-		case SubmitTaskRecord:
-			pending++
-		case RevokedTaskRecord:
-			dropped++
-		}
-	}
-	assert.Equal(t, 1, pending, "only the newest submission stays pending")
-	assert.Equal(t, 1, dropped, "the older pending submission is collapsed to dropped")
+	// Newest-first: records[0] is the second submit.
+	assert.Equal(t, SubmitRecord, records[0].Type)
+	assert.Equal(t, "second attempt", records[0].Content)
+	assert.Equal(t, SubmitRecord, records[1].Type)
+	assert.Equal(t, "first attempt", records[1].Content)
 
-	status, err := db.LatestTaskStatus(student.ID, taskID)
+	// SubmitAt resets on each new submission (different rounds).
+	assert.False(t, records[0].SubmitAt.Equal(records[1].SubmitAt),
+		"each submission starts a new round with its own SubmitAt")
+
+	latest, err := db.LatestTaskRecord(student.ID, taskID)
 	assert.NoError(t, err)
-	assert.Equal(t, SubmitTaskRecord, status)
+	assert.Equal(t, SubmitRecord, latest.Type)
+	assert.Equal(t, "second attempt", latest.Content)
 }
 
 func TestResubmitAfterCheckVisible(t *testing.T) {
@@ -211,17 +187,18 @@ func TestResubmitAfterCheckVisible(t *testing.T) {
 
 	records, err := db.ListTaskRecords(student.ID, taskID)
 	assert.NoError(t, err)
-	firstRecordID := records[0].ID
+	// Newest-first: records[0] is the RegisterRecord.
+	firstRegisterID := records[0].ID
 
-	// Teacher checks it (adds review → first record becomes ReviewedTaskRecord)
-	assert.NoError(t, db.AddTaskRecord(&TaskRecord{
-		TaskID:          taskID,
-		StudentID:       student.ID,
-		EntryAuthorID:   teacher.ID,
-		EntryAuthorName: teacher.Username,
-		Content:         "looks good",
-		CreatedAt:       time.Now(),
-		Status:          ReviewTaskRecord,
+	// Teacher reviews (appends ReviewedRecord; lesson enrollment status updated)
+	assert.NoError(t, db.AppendTaskRecord(&TaskRecord{
+		TaskID:     taskID,
+		StudentID:  student.ID,
+		AuthorID:   teacher.ID,
+		AuthorName: teacher.Username,
+		Content:    "looks good",
+		CreatedAt:  time.Now(),
+		Type:       ReviewedRecord,
 	}))
 
 	// Student submits new entry and re-registers
@@ -231,22 +208,20 @@ func TestResubmitAfterCheckVisible(t *testing.T) {
 	lesson, err := db.GetLesson(lessonID)
 	assert.NoError(t, err)
 	assert.Len(t, lesson.EnrolledTasks, 1, "only new registration should be current")
-	assert.Len(t, lesson.PreviousEnrolledTasks, 1, "checked submission should be in history")
-	assert.Equal(t, ReviewedTaskRecord, lesson.PreviousEnrolledTasks[0].Status)
-	assert.Equal(t, firstRecordID, lesson.PreviousEnrolledTasks[0].TaskRecordID)
+	assert.Len(t, lesson.PreviousEnrolledTasks, 1, "reviewed submission should be in history")
+	assert.Equal(t, ReviewedRecord, lesson.PreviousEnrolledTasks[0].Status)
+	assert.Equal(t, firstRegisterID, lesson.PreviousEnrolledTasks[0].TaskRecordID)
 
 	prev, err := db.ListLessonPreviousTaskRecords(lesson)
 	assert.NoError(t, err)
 	assert.Len(t, prev, 1)
-	assert.Equal(t, ReviewedTaskRecord, prev[0].Status)
+	assert.Equal(t, ReviewedRecord, prev[0].Type)
 	assert.Equal(t, "first attempt", prev[0].Content)
 }
 
 // TestReadTolerateCorruptIndex reproduces issue #45: a task index key holds a
-// JSON object (e.g. from a key collision with a colon-containing task ID)
-// instead of the expected []string. Display reads must degrade to "no records"
-// rather than failing the whole request, which previously 500'd the profile
-// page via the score-rule evaluation path.
+// JSON object instead of the expected []string. Display reads must degrade to
+// "no records" rather than failing the whole request.
 func TestReadTolerateCorruptIndex(t *testing.T) {
 	db, tempDir := setupTestDB(t)
 	defer cleanupTestDB(db, tempDir)
@@ -266,9 +241,9 @@ func TestReadTolerateCorruptIndex(t *testing.T) {
 	assert.NoError(t, err, "ListTaskRecords must not error on a corrupt index")
 	assert.Empty(t, records)
 
-	status, err := db.LatestTaskStatus(userID, taskID)
-	assert.NoError(t, err, "LatestTaskStatus must not error on a corrupt index")
-	assert.Equal(t, TaskRecordStatus(""), status)
+	rec, err := db.LatestTaskRecord(userID, taskID)
+	assert.NoError(t, err, "LatestTaskRecord must not error on a corrupt index")
+	assert.Nil(t, rec)
 }
 
 func TestIsRegistrationOpen(t *testing.T) {
@@ -344,63 +319,63 @@ func TestLessonFlow(t *testing.T) {
 	assert.NotNil(t, lessonID)
 	assert.Regexp(t, "^lesson:teacher:.{8}-.{4}-.{4}-.{4}-.{12}$", lessonID)
 
-	// Create task record
-	submitedTaskRecord := &TaskRecord{
-		TaskID:          taskID,
-		StudentID:       student.ID,
-		EntryAuthorID:   student.ID,
-		EntryAuthorName: student.Username,
-		Content:         taskID + " submittion",
-		CreatedAt:       time.Date(2023, 8, 15, 14, 30, 0, 0, time.UTC),
-		Status:          SubmitTaskRecord,
+	// Create task record (student submits)
+	submitRecord := &TaskRecord{
+		TaskID:     taskID,
+		StudentID:  student.ID,
+		AuthorID:   student.ID,
+		AuthorName: student.Username,
+		Content:    taskID + " submission",
+		CreatedAt:  time.Date(2023, 8, 15, 14, 30, 0, 0, time.UTC),
+		Type:       SubmitRecord,
 	}
-	assert.NoError(t, db.AddTaskRecord(submitedTaskRecord))
+	assert.NoError(t, db.AppendTaskRecord(submitRecord))
 
 	records, err := db.ListTaskRecords(student.ID, taskID)
 	assert.NoError(t, err)
 	assert.Len(t, records, 1)
 	assert.Equal(t, taskID, records[0].TaskID)
-	assert.Equal(t, SubmitTaskRecord, records[0].Status)
+	assert.Equal(t, SubmitRecord, records[0].Type)
 	assert.NotNil(t, records[0].ID)
 	assert.Regexp(t, "^task:student:lab1:.{8}-.{4}-.{4}-.{4}-.{12}$", records[0].ID)
 
-	// Register to the lesson
+	// Register to the lesson (appends a RegisterRecord)
 	assert.NoError(t, db.RegisterToLesson(lessonID, taskID, studentID))
 	lesson, err = db.GetLesson(lessonID)
 	assert.NoError(t, err)
 	assert.Len(t, lesson.EnrolledTasks, 1)
 	assert.Equal(t, taskID, lesson.EnrolledTasks[0].TaskID)
-	assert.Equal(t, student.ID, lesson.EnrolledTasks[0].AuthorID)
-	assert.Equal(t, submitedTaskRecord.ID, lesson.EnrolledTasks[0].TaskRecordID)
+	assert.Equal(t, student.ID, lesson.EnrolledTasks[0].StudentID)
 
 	records, err = db.ListTaskRecords(student.ID, taskID)
 	assert.NoError(t, err)
-	assert.Len(t, records, 1)
+	assert.Len(t, records, 2, "submit + register = 2 immutable records")
 	assert.Equal(t, taskID, records[0].TaskID)
-	assert.Equal(t, RegisterTaskRecord, records[0].Status)
+	assert.Equal(t, RegisterRecord, records[0].Type, "newest record is the register")
+	// Enrolled task points to the RegisterRecord.
+	assert.Equal(t, records[0].ID, lesson.EnrolledTasks[0].TaskRecordID)
 
-	// Teacher submit review on the student work
-	reviewedTaskRecord := &TaskRecord{
-		TaskID:          taskID,
-		StudentID:       student.ID,
-		EntryAuthorID:   teacher.ID,
-		EntryAuthorName: teacher.Username,
-		Content:         taskID + " review",
-		CreatedAt:       time.Date(2023, 8, 15, 15, 30, 0, 0, time.UTC),
-		Status:          ReviewTaskRecord,
-	}
-	assert.NoError(t, db.AddTaskRecord(reviewedTaskRecord))
+	// Teacher submits review
+	assert.NoError(t, db.AppendTaskRecord(&TaskRecord{
+		TaskID:     taskID,
+		StudentID:  student.ID,
+		AuthorID:   teacher.ID,
+		AuthorName: teacher.Username,
+		Content:    taskID + " review",
+		CreatedAt:  time.Now(),
+		Type:       ReviewedRecord,
+	}))
 
-	// List updated task history
+	// List updated task history (3 records: reviewed, register, submit)
 	records, err = db.ListTaskRecords(student.ID, taskID)
 	assert.NoError(t, err)
-	assert.Len(t, records, 2)
+	assert.Len(t, records, 3)
 
 	assert.Equal(t, student.ID, records[0].StudentID)
-	assert.Equal(t, teacher.ID, records[0].EntryAuthorID)
-	assert.Equal(t, ReviewTaskRecord, records[0].Status)
+	assert.Equal(t, teacher.ID, records[0].AuthorID)
+	assert.Equal(t, ReviewedRecord, records[0].Type)
 
 	assert.Equal(t, student.ID, records[1].StudentID)
-	assert.Equal(t, student.ID, records[1].EntryAuthorID)
-	assert.Equal(t, ReviewedTaskRecord, records[1].Status)
+	assert.Equal(t, student.ID, records[1].AuthorID)
+	assert.Equal(t, RegisterRecord, records[1].Type)
 }

--- a/src/storage/legacy_test.go
+++ b/src/storage/legacy_test.go
@@ -1,0 +1,356 @@
+package storage
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	bolt "go.etcd.io/bbolt"
+)
+
+// writeLegacyRecord writes rawJSON under recordKey in the DB bucket and appends
+// recordKey to the task index "tasks:{userID}:{taskID}". Use this to inject
+// synthetic old-format records without going through AppendTaskRecord.
+func writeLegacyRecord(t *testing.T, db *DB, userID, taskID, recordKey string, rawJSON []byte) {
+	t.Helper()
+	err := db.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(db.bucketName)
+		if err := b.Put([]byte(recordKey), rawJSON); err != nil {
+			return err
+		}
+		return appendToIndex(b, "tasks:"+userID+":"+taskID, recordKey)
+	})
+	assert.NoError(t, err)
+}
+
+// TestLegacyFieldNames checks that old field names ("state", "entry_author_id",
+// "entry_author_name") are read back as the correct TaskRecord fields.
+func TestLegacyFieldNames(t *testing.T) {
+	db, tempDir := setupTestDB(t)
+	defer cleanupTestDB(db, tempDir)
+
+	userID := "student1"
+	taskID := "lab1"
+	recordKey := "task:" + userID + ":" + taskID + ":legacy-key-1"
+
+	rawJSON := []byte(fmt.Sprintf(`{
+		"id": %q,
+		"task_id": %q,
+		"student_id": %q,
+		"state": "submit",
+		"entry_author_id": %q,
+		"entry_author_name": "Alice",
+		"content": "solution",
+		"created_at": "2023-01-01T10:00:00Z"
+	}`, recordKey, taskID, userID, userID))
+
+	writeLegacyRecord(t, db, userID, taskID, recordKey, rawJSON)
+
+	records, err := db.ListTaskRecords(userID, taskID)
+	assert.NoError(t, err)
+	assert.Len(t, records, 1)
+	assert.Equal(t, SubmitRecord, records[0].Type)
+	assert.Equal(t, userID, records[0].AuthorID)
+	assert.Equal(t, "Alice", records[0].AuthorName)
+}
+
+// TestLegacyTypeRevoked checks that "state":"revoked" reads back as RevokeRecord
+// from both ListTaskRecords and LatestTaskRecord.
+func TestLegacyTypeRevoked(t *testing.T) {
+	db, tempDir := setupTestDB(t)
+	defer cleanupTestDB(db, tempDir)
+
+	userID := "student2"
+	taskID := "lab2"
+	recordKey := "task:" + userID + ":" + taskID + ":legacy-revoked"
+
+	rawJSON := []byte(fmt.Sprintf(`{
+		"id": %q,
+		"task_id": %q,
+		"student_id": %q,
+		"state": "revoked",
+		"entry_author_id": %q,
+		"entry_author_name": "Bob",
+		"content": "solution",
+		"created_at": "2023-02-01T10:00:00Z"
+	}`, recordKey, taskID, userID, userID))
+
+	writeLegacyRecord(t, db, userID, taskID, recordKey, rawJSON)
+
+	records, err := db.ListTaskRecords(userID, taskID)
+	assert.NoError(t, err)
+	assert.Len(t, records, 1)
+	assert.Equal(t, RevokeRecord, records[0].Type)
+
+	latest, err := db.LatestTaskRecord(userID, taskID)
+	assert.NoError(t, err)
+	assert.NotNil(t, latest)
+	assert.Equal(t, RevokeRecord, latest.Type)
+}
+
+// TestLegacyTypeReview checks that "state":"review" reads back as ReviewedRecord
+// from both ListTaskRecords and LatestTaskRecord.
+func TestLegacyTypeReview(t *testing.T) {
+	db, tempDir := setupTestDB(t)
+	defer cleanupTestDB(db, tempDir)
+
+	userID := "student3"
+	taskID := "lab3"
+	recordKey := "task:" + userID + ":" + taskID + ":legacy-review"
+
+	rawJSON := []byte(fmt.Sprintf(`{
+		"id": %q,
+		"task_id": %q,
+		"student_id": %q,
+		"state": "review",
+		"entry_author_id": "teacher3",
+		"entry_author_name": "Teacher3",
+		"content": "looks good",
+		"created_at": "2023-03-01T10:00:00Z"
+	}`, recordKey, taskID, userID))
+
+	writeLegacyRecord(t, db, userID, taskID, recordKey, rawJSON)
+
+	records, err := db.ListTaskRecords(userID, taskID)
+	assert.NoError(t, err)
+	assert.Len(t, records, 1)
+	assert.Equal(t, ReviewedRecord, records[0].Type)
+
+	latest, err := db.LatestTaskRecord(userID, taskID)
+	assert.NoError(t, err)
+	assert.NotNil(t, latest)
+	assert.Equal(t, ReviewedRecord, latest.Type)
+}
+
+// TestLegacyMissingSubmitAtAndCounter verifies that normalizeLegacyRecords
+// correctly fills SubmitAt and Counter for old records that lack these fields.
+// A student submit followed by a teacher review should result in:
+//   - submit: SubmitAt == CreatedAt, Counter == 1
+//   - teacher review: SubmitAt == submit.CreatedAt (inherited), Counter == 2
+func TestLegacyMissingSubmitAtAndCounter(t *testing.T) {
+	db, tempDir := setupTestDB(t)
+	defer cleanupTestDB(db, tempDir)
+
+	studentID := "student4"
+	teacherID := "teacher4"
+	taskID := "lab4"
+
+	submitCreatedAt := time.Date(2023, 4, 1, 10, 0, 0, 0, time.UTC)
+	reviewCreatedAt := time.Date(2023, 4, 1, 12, 0, 0, 0, time.UTC)
+
+	submitKey := "task:" + studentID + ":" + taskID + ":legacy-submit"
+	reviewKey := "task:" + studentID + ":" + taskID + ":legacy-review"
+
+	submitJSON := []byte(fmt.Sprintf(`{
+		"id": %q,
+		"task_id": %q,
+		"student_id": %q,
+		"state": "submit",
+		"entry_author_id": %q,
+		"entry_author_name": "Student4",
+		"content": "solution",
+		"created_at": %q
+	}`, submitKey, taskID, studentID, studentID, submitCreatedAt.Format(time.RFC3339)))
+
+	reviewJSON := []byte(fmt.Sprintf(`{
+		"id": %q,
+		"task_id": %q,
+		"student_id": %q,
+		"state": "review",
+		"entry_author_id": %q,
+		"entry_author_name": "Teacher4",
+		"content": "looks good",
+		"created_at": %q
+	}`, reviewKey, taskID, studentID, teacherID, reviewCreatedAt.Format(time.RFC3339)))
+
+	writeLegacyRecord(t, db, studentID, taskID, submitKey, submitJSON)
+	writeLegacyRecord(t, db, studentID, taskID, reviewKey, reviewJSON)
+
+	// ListTaskRecords returns newest-first: records[0] = review, records[1] = submit.
+	records, err := db.ListTaskRecords(studentID, taskID)
+	assert.NoError(t, err)
+	assert.Len(t, records, 2)
+
+	submitRecord := records[1] // oldest
+	reviewRecord := records[0] // newest
+
+	// Submit: SubmitAt filled from its own CreatedAt; Counter = 1.
+	assert.Equal(t, SubmitRecord, submitRecord.Type)
+	assert.True(t, submitRecord.SubmitAt.Equal(submitCreatedAt),
+		"submit SubmitAt should equal its own CreatedAt, got %v want %v",
+		submitRecord.SubmitAt, submitCreatedAt)
+	assert.Equal(t, 1, submitRecord.Counter)
+
+	// Teacher review: SubmitAt inherited from previous submit's SubmitAt; Counter = 2.
+	assert.Equal(t, ReviewedRecord, reviewRecord.Type)
+	assert.True(t, reviewRecord.SubmitAt.Equal(submitCreatedAt),
+		"teacher review SubmitAt should equal submit CreatedAt, got %v want %v",
+		reviewRecord.SubmitAt, submitCreatedAt)
+	assert.Equal(t, 2, reviewRecord.Counter)
+}
+
+// TestLegacyEnrolledTaskStatusRevoked simulates an old database where the lesson
+// JSON contains "status":"revoked" (legacy value) rather than "status":"revoke".
+// It verifies that EnrolledTask.UnmarshalJSON normalizes the value on read and
+// that RevokedCount() and ListLessonPreviousTaskRecords return correct results.
+func TestLegacyEnrolledTaskStatusRevoked(t *testing.T) {
+	db, tempDir := setupTestDB(t)
+	defer cleanupTestDB(db, tempDir)
+
+	teacher := &UserData{ID: "teacher5", Username: "Teacher5", IsTeacher: true}
+	assert.NoError(t, db.SaveUser(teacher))
+	student := &UserData{ID: "student5", Username: "Student5", IsStudent: true}
+	assert.NoError(t, db.SaveUser(student))
+
+	lesson := &Lesson{
+		DateTime:    time.Now().Add(24 * time.Hour),
+		TeacherID:   teacher.ID,
+		TeacherName: teacher.Username,
+		Description: "test lesson",
+	}
+	assert.NoError(t, db.AddLesson(lesson))
+	lessons, err := db.ListLessons()
+	assert.NoError(t, err)
+	lessonID := LessonID(lessons[0].ID)
+
+	taskID := TaskID("lab5")
+
+	// Student submits, registers, then unregisters; this writes "revoke" to disk.
+	assert.NoError(t, db.AppendTaskRecord(&TaskRecord{
+		TaskID:     taskID,
+		StudentID:  student.ID,
+		AuthorID:   student.ID,
+		AuthorName: student.Username,
+		Content:    "my solution",
+		CreatedAt:  time.Now(),
+		Type:       SubmitRecord,
+	}))
+	assert.NoError(t, db.RegisterToLesson(lessonID, taskID, student.ID))
+	assert.NoError(t, db.UnregisterFromLesson(lessonID, taskID, student.ID))
+
+	// Overwrite the lesson's bucket value: replace "revoke" with "revoked" to
+	// simulate the legacy on-disk format.
+	err = db.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(db.bucketName)
+		data := b.Get([]byte(lessonID))
+		if data == nil {
+			return fmt.Errorf("lesson %q not found in bucket", lessonID)
+		}
+		corrupted := bytes.ReplaceAll(data, []byte(`"revoke"`), []byte(`"revoked"`))
+		return b.Put([]byte(lessonID), corrupted)
+	})
+	assert.NoError(t, err)
+
+	// GetLesson must normalize "revoked" -> RevokeRecord via EnrolledTask.UnmarshalJSON.
+	updatedLesson, err := db.GetLesson(lessonID)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, updatedLesson.RevokedCount())
+
+	// ListLessonPreviousTaskRecords must return the record with Type == RevokeRecord.
+	prev, err := db.ListLessonPreviousTaskRecords(updatedLesson)
+	assert.NoError(t, err)
+	assert.Len(t, prev, 1)
+	assert.Equal(t, RevokeRecord, prev[0].Type)
+}
+
+// TestLegacyMutableModelSingleRecord simulates the old mutable model where a
+// student's submit was mutated in-place to "reviewed". A single record with
+// "state":"reviewed" and student authorship should:
+//   - Read back as ReviewedRecord with SubmitAt == CreatedAt.
+//   - Block RegisterToLesson (ReviewedRecord is not a valid registration state).
+//   - Allow RegisterToLesson after a new SubmitRecord is appended.
+func TestLegacyMutableModelSingleRecord(t *testing.T) {
+	db, tempDir := setupTestDB(t)
+	defer cleanupTestDB(db, tempDir)
+
+	teacher := &UserData{ID: "teacher6", Username: "Teacher6", IsTeacher: true}
+	assert.NoError(t, db.SaveUser(teacher))
+	student := &UserData{ID: "student6", Username: "Student6", IsStudent: true}
+	assert.NoError(t, db.SaveUser(student))
+
+	lesson := &Lesson{
+		DateTime:    time.Now().Add(24 * time.Hour),
+		TeacherID:   teacher.ID,
+		TeacherName: teacher.Username,
+		Description: "test lesson",
+	}
+	assert.NoError(t, db.AddLesson(lesson))
+	lessons, err := db.ListLessons()
+	assert.NoError(t, err)
+	lessonID := LessonID(lessons[0].ID)
+
+	taskID := TaskID("lab6")
+	createdAt := time.Date(2023, 6, 1, 10, 0, 0, 0, time.UTC)
+	recordKey := "task:" + student.ID + ":" + taskID + ":legacy-mutable"
+
+	// Simulate old mutable model: single record with "state":"reviewed",
+	// student-authored (student_id == entry_author_id).
+	rawJSON := []byte(fmt.Sprintf(`{
+		"id": %q,
+		"task_id": %q,
+		"student_id": %q,
+		"state": "reviewed",
+		"entry_author_id": %q,
+		"entry_author_name": %q,
+		"content": "my solution",
+		"created_at": %q
+	}`, recordKey, taskID, student.ID, student.ID, student.Username, createdAt.Format(time.RFC3339)))
+
+	writeLegacyRecord(t, db, student.ID, taskID, recordKey, rawJSON)
+
+	// LatestTaskRecord should return ReviewedRecord.
+	latest, err := db.LatestTaskRecord(student.ID, taskID)
+	assert.NoError(t, err)
+	assert.NotNil(t, latest)
+	assert.Equal(t, ReviewedRecord, latest.Type)
+
+	// Student-authored reviewed: SubmitAt should equal CreatedAt.
+	assert.True(t, latest.SubmitAt.Equal(createdAt),
+		"student-authored reviewed: SubmitAt should equal CreatedAt, got %v want %v",
+		latest.SubmitAt, createdAt)
+
+	// RegisterToLesson should fail: ReviewedRecord is not a valid registration state.
+	err = db.RegisterToLesson(lessonID, taskID, student.ID)
+	assert.Error(t, err, "RegisterToLesson should fail when latest record is ReviewedRecord")
+
+	// After appending a new SubmitRecord, RegisterToLesson should succeed.
+	assert.NoError(t, db.AppendTaskRecord(&TaskRecord{
+		TaskID:     taskID,
+		StudentID:  student.ID,
+		AuthorID:   student.ID,
+		AuthorName: student.Username,
+		Content:    "updated solution",
+		CreatedAt:  time.Now(),
+		Type:       SubmitRecord,
+	}))
+	assert.NoError(t, db.RegisterToLesson(lessonID, taskID, student.ID))
+}
+
+// TestReadTolerateCorruptIndex reproduces issue #45: a task index key holds a
+// JSON object instead of the expected []string. Display reads must degrade to
+// "no records" rather than failing the whole request.
+func TestReadTolerateCorruptIndex(t *testing.T) {
+	db, tempDir := setupTestDB(t)
+	defer cleanupTestDB(db, tempDir)
+
+	userID := "409529"
+	taskID := TaskID("ac:2026:scheme")
+	indexKey := "tasks:" + userID + ":" + taskID
+
+	// Write a JSON object where a []string index is expected.
+	err := db.db.Update(func(tx *bolt.Tx) error {
+		b := tx.Bucket(db.bucketName)
+		return b.Put([]byte(indexKey), []byte(`{"id":"409529","journals":{}}`))
+	})
+	assert.NoError(t, err)
+
+	records, err := db.ListTaskRecords(userID, taskID)
+	assert.NoError(t, err, "ListTaskRecords must not error on a corrupt index")
+	assert.Empty(t, records)
+
+	rec, err := db.LatestTaskRecord(userID, taskID)
+	assert.NoError(t, err, "LatestTaskRecord must not error on a corrupt index")
+	assert.Nil(t, rec)
+}

--- a/src/storage/lesson.go
+++ b/src/storage/lesson.go
@@ -36,18 +36,18 @@ func (l Lesson) IsRegistrationOpen() bool {
 }
 
 type EnrolledTask struct {
-	TaskRecordID TaskRecordID     `json:"journal_entry_id"`
-	Status       TaskRecordStatus `json:"status"`
-
-	AuthorID       UserID `json:"user_id"`
-	TaskID         TaskID `json:"task_id"`
-	TaskRecordDesc string `json:"description"`
+	TaskRecordID string    `json:"journal_entry_id"`
+	StudentID    string    `json:"user_id"`
+	TaskID       string    `json:"task_id"`
+	Excerpt      string    `json:"description"`
+	Status       string    `json:"status"`
+	SubmitAt     time.Time `json:"submit_at"`
 }
 
 func (l *Lesson) RegisteredCount() int {
 	count := 0
 	for _, t := range l.EnrolledTasks {
-		if t.Status == RegisterTaskRecord || t.Status == ReviewedTaskRecord {
+		if t.Status == RegisterRecord || t.Status == ReviewedRecord {
 			count++
 		}
 	}
@@ -57,7 +57,7 @@ func (l *Lesson) RegisteredCount() int {
 func (l *Lesson) ReviewedCount() int {
 	count := 0
 	for _, t := range l.EnrolledTasks {
-		if t.Status == ReviewedTaskRecord {
+		if t.Status == ReviewedRecord {
 			count++
 		}
 	}
@@ -67,7 +67,7 @@ func (l *Lesson) ReviewedCount() int {
 func (l *Lesson) RevokedCount() int {
 	count := 0
 	for _, t := range l.PreviousEnrolledTasks {
-		if t.Status == RevokedTaskRecord {
+		if t.Status == RevokeRecord {
 			count++
 		}
 	}
@@ -178,20 +178,29 @@ func (d *DB) DeleteLesson(lessonID LessonID, teacherID UserID) error {
 			return err
 		}
 
-		// Reset registered task records back to submit state
+		// Append a RevokeRecord for each currently-registered enrollment so
+		// students can re-register to another lesson without resubmitting.
 		for _, enrolled := range lesson.EnrolledTasks {
-			if enrolled.Status == RegisterTaskRecord {
-				taskRecord, err := getValue[TaskRecord](b, enrolled.TaskRecordID)
-				if err != nil {
-					return err
-				}
-				taskRecord.Status = SubmitTaskRecord
-				taskRecord.LessonAt = time.Time{}
-				taskRecord.LessonID = ""
-				if err := setValue(b, taskRecord.ID, *taskRecord); err != nil {
-					return err
-				}
+			if enrolled.Status != RegisterRecord {
+				continue
 			}
+			regRecord, err := readRecordRaw(b, enrolled.TaskRecordID)
+			if err != nil {
+				continue // best-effort; skip on error
+			}
+			revokeRecord := TaskRecord{
+				TaskID:     enrolled.TaskID,
+				StudentID:  enrolled.StudentID,
+				AuthorID:   enrolled.StudentID,
+				AuthorName: regRecord.AuthorName,
+				Type:       RevokeRecord,
+				LessonID:   lessonID,
+				CreatedAt:  time.Now(),
+				SubmitAt:   regRecord.SubmitAt,
+				Counter:    regRecord.Counter + 1,
+				Content:    regRecord.Content,
+			}
+			_ = appendRecordInTx(b, &revokeRecord) // best-effort
 		}
 
 		if err := removeFromIndex(b, lessonsKey, lessonID); err != nil {
@@ -233,10 +242,16 @@ func (d *DB) ListLessonTaskRecords(lesson *Lesson) ([]*TaskRecord, error) {
 	err := d.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(d.bucketName)
 		for _, enrolledTask := range lesson.EnrolledTasks {
-			taskRecordID := enrolledTask.TaskRecordID
-			taskRecord, err := getValue[TaskRecord](b, taskRecordID)
+			taskRecord, err := readRecordRaw(b, enrolledTask.TaskRecordID)
 			if err != nil {
 				return err
+			}
+			// In the immutable model the record at TaskRecordID is a RegisterRecord.
+			// Use EnrolledTask.Status as the effective status for lesson display so
+			// handlers can detect reviewed/revoked states correctly.
+			taskRecord.Type = enrolledTask.Status
+			if taskRecord.SubmitAt.IsZero() {
+				taskRecord.SubmitAt = enrolledTask.SubmitAt
 			}
 			result = append(result, taskRecord)
 		}
@@ -254,9 +269,15 @@ func (d *DB) ListLessonPreviousTaskRecords(lesson *Lesson) ([]*TaskRecord, error
 	err := d.db.View(func(tx *bolt.Tx) error {
 		b := tx.Bucket(d.bucketName)
 		for _, enrolledTask := range lesson.PreviousEnrolledTasks {
-			taskRecord, err := getValue[TaskRecord](b, enrolledTask.TaskRecordID)
+			taskRecord, err := readRecordRaw(b, enrolledTask.TaskRecordID)
 			if err != nil {
 				return err
+			}
+			// Use EnrolledTask.Status as the effective status so handlers can
+			// distinguish reviewed from revoked previous enrollments.
+			taskRecord.Type = enrolledTask.Status
+			if taskRecord.SubmitAt.IsZero() {
+				taskRecord.SubmitAt = enrolledTask.SubmitAt
 			}
 			result = append(result, taskRecord)
 		}

--- a/src/storage/lesson.go
+++ b/src/storage/lesson.go
@@ -36,12 +36,12 @@ func (l Lesson) IsRegistrationOpen() bool {
 }
 
 type EnrolledTask struct {
-	TaskRecordID string    `json:"journal_entry_id"`
-	StudentID    string    `json:"user_id"`
-	TaskID       string    `json:"task_id"`
-	Excerpt      string    `json:"description"`
-	Status       string    `json:"status"`
-	SubmitAt     time.Time `json:"submit_at"`
+	TaskRecordID string         `json:"journal_entry_id"`
+	StudentID    string         `json:"user_id"`
+	TaskID       string         `json:"task_id"`
+	Excerpt      string         `json:"description"`
+	Status       TaskRecordType `json:"status"`
+	SubmitAt     time.Time      `json:"submit_at"`
 }
 
 func (l *Lesson) RegisteredCount() int {

--- a/src/storage/lesson.go
+++ b/src/storage/lesson.go
@@ -44,6 +44,19 @@ type EnrolledTask struct {
 	SubmitAt     time.Time      `json:"submit_at"`
 }
 
+// UnmarshalJSON normalizes the Status field so old on-disk values like
+// "revoked" and "review" are mapped to their canonical forms on every read.
+func (e *EnrolledTask) UnmarshalJSON(data []byte) error {
+	type raw EnrolledTask // break recursion
+	var r raw
+	if err := json.Unmarshal(data, &r); err != nil {
+		return err
+	}
+	*e = EnrolledTask(r)
+	e.Status = normalizeType(e.Status)
+	return nil
+}
+
 func (l *Lesson) RegisteredCount() int {
 	count := 0
 	for _, t := range l.EnrolledTasks {

--- a/src/storage/task.go
+++ b/src/storage/task.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"encoding/json"
 	"fmt"
 	"log"
 	"sort"
@@ -14,47 +15,41 @@ import (
 type TaskID = string
 type TaskRecordID = string
 
-type TaskRecordStatus string
-
+// Record type constants. These are the canonical values stored in the Type field.
 const (
-	SubmitTaskRecord   TaskRecordStatus = "submit"
-	RegisterTaskRecord TaskRecordStatus = "register"
-	RevokedTaskRecord  TaskRecordStatus = "revoked"
-	ReviewTaskRecord   TaskRecordStatus = "review"
-	ReviewedTaskRecord TaskRecordStatus = "reviewed"
+	SubmitRecord   = "submit"
+	RegisterRecord = "register"
+	RevokeRecord   = "revoke"
+	ReviewedRecord = "reviewed"
 )
 
 type TaskRecord struct {
-	ID              TaskRecordID     `json:"id"`
-	TaskID          TaskID           `json:"task_id"`
-	StudentID       UserID           `json:"student_id"`
-	EntryAuthorID   UserID           `json:"entry_author_id"`
-	Content         string           `json:"content"`
-	Status          TaskRecordStatus `json:"state"`
-	CreatedAt       time.Time        `json:"created_at"`
-	RegisteredAt    time.Time        `json:"registered_at"`
-	EntryAuthorName string           `json:"entry_author_name"`
-	LessonAt        time.Time        `json:"lesson_at"`
-	LessonID        LessonID         `json:"lesson_id"`
+	ID         string    `json:"id"`
+	TaskID     string    `json:"task_id"`
+	StudentID  string    `json:"student_id"`
+	AuthorID   string    `json:"author_id"`
+	AuthorName string    `json:"author_name"`
+	Type       string    `json:"type"`
+	Counter    int       `json:"counter"`
+	CreatedAt  time.Time `json:"created_at"`
+	SubmitAt   time.Time `json:"submit_at"`
+	Content    string    `json:"content"`
+	LessonID   string    `json:"lesson_id"`
 }
 
 func (r *TaskRecord) RenderAt() string {
 	return r.CreatedAt.Format("2006-01-02 15:04:05")
 }
 
-// Both sorts are stable and expect records in index (append) order: a revoke
-// leaves the dropped record in place and appends a fresh pending record that
-// carries the original CreatedAt (so the student keeps their queue position).
-// That makes ties on CreatedAt normal; on a tie the later-appended record is
-// the newer one, so oldest-first keeps append order while newest-first must
-// reverse it — otherwise the dropped record would shadow the pending
-// resubmission as the latest record.
+// SortTaskRecordsOldestFirst sorts a slice of TaskRecord pointers oldest-first by CreatedAt.
 func SortTaskRecordsOldestFirst(records []*TaskRecord) {
 	sort.SliceStable(records, func(i, j int) bool {
 		return records[i].CreatedAt.Before(records[j].CreatedAt)
 	})
 }
 
+// SortTaskRecordsNewestFirst reverses then stable-sorts a slice of TaskRecord
+// values newest-first by CreatedAt.
 func SortTaskRecordsNewestFirst(records []TaskRecord) {
 	for i, j := 0, len(records)-1; i < j; i, j = i+1, j-1 {
 		records[i], records[j] = records[j], records[i]
@@ -64,8 +59,125 @@ func SortTaskRecordsNewestFirst(records []TaskRecord) {
 	})
 }
 
-func (d *DB) AddTaskRecord(record *TaskRecord) error {
-	if record.TaskID == "" || record.StudentID == "" || record.EntryAuthorName == "" || record.Content == "" || record.Status == "" {
+// legacyTaskRecord is used only during unmarshalling to capture both old and
+// new field names. Call toTaskRecord() to obtain a TaskRecord.
+type legacyTaskRecord struct {
+	TaskRecord
+	LegacyStatus     string `json:"state"`             // old Status field (JSON tag was "state")
+	LegacyAuthorID   string `json:"entry_author_id"`   // old EntryAuthorID
+	LegacyAuthorName string `json:"entry_author_name"` // old EntryAuthorName
+}
+
+func (l *legacyTaskRecord) toTaskRecord() TaskRecord {
+	r := l.TaskRecord
+	if r.Type == "" && l.LegacyStatus != "" {
+		r.Type = l.LegacyStatus
+	}
+	if r.AuthorID == "" && l.LegacyAuthorID != "" {
+		r.AuthorID = l.LegacyAuthorID
+	}
+	if r.AuthorName == "" && l.LegacyAuthorName != "" {
+		r.AuthorName = l.LegacyAuthorName
+	}
+	return r
+}
+
+// readRecordRaw reads and unmarshals a single record from the bucket, handling
+// both legacy and current JSON field names via legacyTaskRecord.
+func readRecordRaw(b *bolt.Bucket, key string) (*TaskRecord, error) {
+	data := b.Get([]byte(key))
+	if data == nil {
+		return nil, fmt.Errorf("not found: %s", key)
+	}
+	var lr legacyTaskRecord
+	if err := json.Unmarshal(data, &lr); err != nil {
+		return nil, fmt.Errorf("could not unmarshal task record %q: %w", key, err)
+	}
+	r := lr.toTaskRecord()
+	return &r, nil
+}
+
+// normalizeLegacyRecords fills in missing SubmitAt and Counter values and maps
+// legacy Type strings to canonical names. It sorts records oldest-first and
+// returns them in that order. This is a backward-compat shim; it can be
+// removed once no databases with legacy records exist.
+func normalizeLegacyRecords(records []TaskRecord) []TaskRecord {
+	sort.SliceStable(records, func(i, j int) bool {
+		return records[i].CreatedAt.Before(records[j].CreatedAt)
+	})
+
+	var prevSubmitAt time.Time
+	counter := 0
+
+	for i := range records {
+		r := &records[i]
+
+		// Step 1: fill SubmitAt for legacy records that lack it.
+		if r.SubmitAt.IsZero() {
+			isStudentAuthored := r.AuthorID == r.StudentID
+			switch r.Type {
+			case "submit", "register", "revoked":
+				// These legacy types each represent the student's submission or a
+				// mutation of it; treat CreatedAt as the round-start time.
+				r.SubmitAt = r.CreatedAt
+			case "review", "reviewed":
+				// "review" is the old on-disk value for a teacher review (now
+				// "reviewed"). If the record is student-authored it is the original
+				// submit that was mutated to reviewed status by the old mutable model.
+				if isStudentAuthored {
+					r.SubmitAt = r.CreatedAt
+				} else {
+					r.SubmitAt = prevSubmitAt
+				}
+			default:
+				r.SubmitAt = prevSubmitAt
+			}
+		}
+
+		// Step 2: assign Counter sequentially, resetting to 1 when SubmitAt changes.
+		if !r.SubmitAt.Equal(prevSubmitAt) {
+			counter = 1
+		} else {
+			counter++
+		}
+		r.Counter = counter
+		prevSubmitAt = r.SubmitAt
+
+		// Step 3: map legacy type strings to canonical names.
+		switch r.Type {
+		case "revoked":
+			r.Type = RevokeRecord
+		case "review":
+			r.Type = ReviewedRecord
+		}
+	}
+
+	return records
+}
+
+// readAndNormalizeRecords reads all records for the given index keys, applies
+// legacy normalization, and returns them oldest-first.
+func readAndNormalizeRecords(b *bolt.Bucket, keys []string) ([]TaskRecord, error) {
+	records := make([]TaskRecord, 0, len(keys))
+	for _, key := range keys {
+		r, err := readRecordRaw(b, key)
+		if err != nil {
+			return nil, err
+		}
+		records = append(records, *r)
+	}
+	return normalizeLegacyRecords(records), nil
+}
+
+// AppendTaskRecord appends a new immutable record to the event log for a
+// student/task pair. Counter and SubmitAt are derived from the latest existing
+// record:
+//   - Type == SubmitRecord: SubmitAt = time.Now(), Counter = 1
+//   - Any other type:       SubmitAt = latest.SubmitAt, Counter = latest.Counter+1
+//
+// AuthorName, Content, Type, TaskID, and StudentID are all required.
+func (d *DB) AppendTaskRecord(record *TaskRecord) error {
+	if record.TaskID == "" || record.StudentID == "" || record.AuthorName == "" || record.Content == "" || record.Type == "" {
 		return fmt.Errorf("task record validation error")
 	}
 
@@ -81,76 +193,52 @@ func (d *DB) AddTaskRecord(record *TaskRecord) error {
 			return err
 		}
 
-		for _, key := range taskRecordKeys {
-			existingRecord, err := getValue[TaskRecord](b, key)
-			if err != nil {
-				return err
-			}
-
-			if existingRecord.Status == RegisterTaskRecord {
-				if record.Status == ReviewTaskRecord {
-					existingRecord.Status = ReviewedTaskRecord
-				} else {
-					existingRecord.Status = RevokedTaskRecord
-				}
-				if err := setValue(b, key, existingRecord); err != nil {
+		if record.Type == SubmitRecord {
+			record.SubmitAt = time.Now()
+			record.Counter = 1
+		} else {
+			if len(taskRecordKeys) > 0 {
+				existing, err := readAndNormalizeRecords(b, taskRecordKeys)
+				if err != nil {
 					return err
 				}
-				// Sync status back to the EnrolledTask in the lesson
-				if existingRecord.LessonID != "" {
-					if lesson, err := getValue[Lesson](b, existingRecord.LessonID); err == nil {
-						for i, enrolled := range lesson.EnrolledTasks {
-							if enrolled.TaskRecordID == existingRecord.ID {
-								lesson.EnrolledTasks[i].Status = existingRecord.Status
-								_ = setValue(b, existingRecord.LessonID, *lesson)
+				latest := existing[len(existing)-1]
+				record.SubmitAt = latest.SubmitAt
+				record.Counter = latest.Counter + 1
+
+				// When a teacher adds a ReviewedRecord while the student has an
+				// active lesson registration (a RegisterRecord with a LessonID),
+				// update the lesson's enrolled-task status so ReviewedCount() stays
+				// accurate without mutating any task record.
+				if record.Type == ReviewedRecord &&
+					record.AuthorID != record.StudentID &&
+					latest.LessonID != "" &&
+					latest.Type == RegisterRecord {
+					if lesson, err := getValue[Lesson](b, latest.LessonID); err == nil {
+						for j, enrolled := range lesson.EnrolledTasks {
+							if enrolled.TaskRecordID == latest.ID {
+								lesson.EnrolledTasks[j].Status = ReviewedRecord
+								_ = setValue(b, latest.LessonID, *lesson)
 								break
 							}
 						}
 					}
 				}
-			} else if existingRecord.Status == SubmitTaskRecord {
-				// Only the newest submission stays pending; collapse any older
-				// pending record (which is not enrolled in a lesson) to dropped.
-				existingRecord.Status = RevokedTaskRecord
-				if err := setValue(b, key, existingRecord); err != nil {
-					return err
-				}
+			} else {
+				record.SubmitAt = record.CreatedAt
+				record.Counter = 1
 			}
-
 		}
 
-		err = appendToIndex(b, indexKey, newRecordKey)
-		if err != nil {
+		if err := appendToIndex(b, indexKey, newRecordKey); err != nil {
 			return err
 		}
 		return setValue(b, newRecordKey, record)
 	})
 }
 
-// appendPendingResubmission re-creates the student's submission as a fresh
-// pending record after a revoke. The dropped record is left untouched as
-// immutable history; the new record copies the content and — crucially — the
-// original CreatedAt, so the student keeps their place in the submit-ordered
-// queue instead of being pushed to the back. It must be called from within an
-// open write transaction on bucket b.
-func appendPendingResubmission(b *bolt.Bucket, revoked *TaskRecord) error {
-	indexKey := "tasks:" + revoked.StudentID + ":" + revoked.TaskID
-	newKey := "task:" + revoked.StudentID + ":" + revoked.TaskID + ":" + uuid.New().String()
-
-	resubmission := *revoked
-	resubmission.ID = newKey
-	resubmission.Status = SubmitTaskRecord
-	resubmission.RegisteredAt = time.Time{}
-	resubmission.LessonAt = time.Time{}
-	resubmission.LessonID = ""
-	// CreatedAt is intentionally kept from the revoked record to preserve queue position.
-
-	if err := appendToIndex(b, indexKey, newKey); err != nil {
-		return err
-	}
-	return setValue(b, newKey, resubmission)
-}
-
+// ListTaskRecords returns all task records for a student/task pair, normalized
+// for legacy format and sorted newest-first.
 func (d *DB) ListTaskRecords(userID string, taskID TaskID) ([]TaskRecord, error) {
 	if userID == "" || taskID == "" {
 		return nil, fmt.Errorf("user ID and task ID cannot be empty")
@@ -164,22 +252,17 @@ func (d *DB) ListTaskRecords(userID string, taskID TaskID) ([]TaskRecord, error)
 		taskRecordKeys, err := getIndex(b, indexKey)
 		if err != nil {
 			// A corrupt or colliding index (e.g. a struct stored under a
-			// colon-containing task ID, see issue #45) must not break the
-			// whole read — degrade to "no records" so the profile page renders.
-			// Log the raw stored value to help diagnose the corruption source.
+			// colon-containing task ID, see issue #45) must not break the whole
+			// read — degrade to "no records" so the profile page renders.
 			log.Printf("Warning: unreadable task index %q, treating as empty: %v (raw value: %s)", indexKey, err, b.Get([]byte(indexKey)))
 			return nil
 		}
 
-		taskRecords := make([]TaskRecord, len(taskRecordKeys))
-		for i, key := range taskRecordKeys {
-			taskRecord, err := getValue[TaskRecord](b, key)
-			if err != nil {
-				return err
-			}
-			taskRecords[i] = *taskRecord
+		records, err := readAndNormalizeRecords(b, taskRecordKeys)
+		if err != nil {
+			return err
 		}
-		result = taskRecords
+		result = records
 		return nil
 	})
 
@@ -187,37 +270,40 @@ func (d *DB) ListTaskRecords(userID string, taskID TaskID) ([]TaskRecord, error)
 		return nil, err
 	}
 
+	// normalizeLegacyRecords returns oldest-first; reverse to newest-first.
 	SortTaskRecordsNewestFirst(result)
 	return result, nil
 }
 
-// LatestTaskStatus returns the status of the most recently added record for a
-// given user/task pair, or an empty string if no records exist.
-func (d *DB) LatestTaskStatus(userID string, taskID TaskID) (TaskRecordStatus, error) {
+// LatestTaskRecord returns the most recently appended record for a student/task
+// pair (after normalization), or nil if no records exist.
+func (d *DB) LatestTaskRecord(userID string, taskID TaskID) (*TaskRecord, error) {
 	if userID == "" || taskID == "" {
-		return "", fmt.Errorf("user ID and task ID cannot be empty")
+		return nil, fmt.Errorf("user ID and task ID cannot be empty")
 	}
 
-	var status TaskRecordStatus
-	err := d.db.View(func(tx *bolt.Tx) error {
-		b := tx.Bucket(d.bucketName)
-		indexKey := "tasks:" + userID + ":" + taskID
-		keys, err := getIndex(b, indexKey)
-		if err != nil {
-			log.Printf("Warning: unreadable task index %q, treating as empty: %v (raw value: %s)", indexKey, err, b.Get([]byte(indexKey)))
-			return nil
-		}
-		if len(keys) == 0 {
-			return nil
-		}
-		record, err := getValue[TaskRecord](b, keys[len(keys)-1])
-		if err != nil {
-			return err
-		}
-		status = record.Status
-		return nil
-	})
-	return status, err
+	records, err := d.ListTaskRecords(userID, taskID)
+	if err != nil {
+		return nil, err
+	}
+	if len(records) == 0 {
+		return nil, nil
+	}
+	r := records[0] // newest-first; index 0 is the latest
+	return &r, nil
+}
+
+// appendRecordInTx writes a new record and appends its key to the index inside
+// an existing write transaction. Callers must set all fields including SubmitAt
+// and Counter themselves.
+func appendRecordInTx(b *bolt.Bucket, record *TaskRecord) error {
+	indexKey := "tasks:" + record.StudentID + ":" + record.TaskID
+	newKey := "task:" + record.StudentID + ":" + record.TaskID + ":" + uuid.New().String()
+	record.ID = newKey
+	if err := appendToIndex(b, indexKey, newKey); err != nil {
+		return err
+	}
+	return setValue(b, newKey, *record)
 }
 
 func (d *DB) RegisterToLesson(lessonID LessonID, taskID TaskID, authorID UserID, waitingPeriod ...time.Duration) error {
@@ -236,16 +322,23 @@ func (d *DB) RegisterToLesson(lessonID LessonID, taskID TaskID, authorID UserID,
 			return fmt.Errorf("no task entries found for author %s and task %s", authorID, taskID)
 		}
 
-		// Check waiting period since last teacher review
+		records, err := readAndNormalizeRecords(b, keys)
+		if err != nil {
+			return err
+		}
+		// records is oldest-first; the latest is the last element.
+		latest := records[len(records)-1]
+
+		if latest.Type != SubmitRecord && latest.Type != RevokeRecord {
+			return fmt.Errorf("unexpected task state for registration on lesson: %s", latest.Type)
+		}
+
+		// Check waiting period since last teacher review.
 		if len(waitingPeriod) > 0 && waitingPeriod[0] > 0 {
-			for i := len(keys) - 1; i >= 0; i-- {
-				rec, err := getValue[TaskRecord](b, keys[i])
-				if err != nil {
-					return err
-				}
-				if rec.Status == ReviewTaskRecord {
-					if time.Since(rec.CreatedAt) < waitingPeriod[0] {
-						remaining := waitingPeriod[0] - time.Since(rec.CreatedAt)
+			for i := len(records) - 1; i >= 0; i-- {
+				if records[i].Type == ReviewedRecord {
+					if time.Since(records[i].CreatedAt) < waitingPeriod[0] {
+						remaining := waitingPeriod[0] - time.Since(records[i].CreatedAt)
 						hours := int(remaining.Hours())
 						minutes := int(remaining.Minutes()) % 60
 						return fmt.Errorf("waiting period: %dh%dm remaining since last check", hours, minutes)
@@ -264,48 +357,46 @@ func (d *DB) RegisterToLesson(lessonID LessonID, taskID TaskID, authorID UserID,
 			return fmt.Errorf("registration is closed")
 		}
 
-		// Check for existing enrollment for same task+author
+		// Check for an existing enrollment for the same task+student.
 		existingIdx := -1
 		for i, enrolled := range lesson.EnrolledTasks {
-			if enrolled.TaskID == taskID && enrolled.AuthorID == authorID {
+			if enrolled.TaskID == taskID && enrolled.StudentID == authorID {
 				existingIdx = i
 				break
 			}
 		}
 		if existingIdx >= 0 {
-			// Duplicate: same record already registered
-			if lesson.EnrolledTasks[existingIdx].TaskRecordID == keys[len(keys)-1] {
-				return fmt.Errorf("already registered")
-			}
-			// Move old enrollment to history before replacing
+			// Move old enrollment to history before replacing.
 			lesson.PreviousEnrolledTasks = append(lesson.PreviousEnrolledTasks, lesson.EnrolledTasks[existingIdx])
 			lesson.EnrolledTasks = append(lesson.EnrolledTasks[:existingIdx], lesson.EnrolledTasks[existingIdx+1:]...)
 		}
 
-		lastTaskRecord, err := getValue[TaskRecord](b, keys[len(keys)-1])
-		if err != nil {
+		// Append a new immutable RegisterRecord.
+		newRecord := TaskRecord{
+			TaskID:     taskID,
+			StudentID:  authorID,
+			AuthorID:   authorID,
+			AuthorName: latest.AuthorName,
+			Type:       RegisterRecord,
+			LessonID:   lessonID,
+			CreatedAt:  time.Now(),
+			SubmitAt:   latest.SubmitAt,
+			Counter:    latest.Counter + 1,
+			Content:    latest.Content,
+		}
+		if err := appendRecordInTx(b, &newRecord); err != nil {
 			return err
 		}
-		if lastTaskRecord.Status != SubmitTaskRecord {
-			return fmt.Errorf("unexpected task state for registration on lesson: %s", lastTaskRecord.Status)
-		}
-		lastTaskRecord.Status = RegisterTaskRecord
-		lastTaskRecord.RegisteredAt = time.Now()
 
 		lesson.EnrolledTasks = append(lesson.EnrolledTasks, EnrolledTask{
-			TaskID:         taskID,
-			AuthorID:       authorID,
-			TaskRecordID:   lastTaskRecord.ID,
-			TaskRecordDesc: lastTaskRecord.Content,
-			Status:         RegisterTaskRecord,
+			TaskID:       taskID,
+			StudentID:    authorID,
+			TaskRecordID: newRecord.ID,
+			Excerpt:      newRecord.Content,
+			Status:       RegisterRecord,
+			SubmitAt:     newRecord.SubmitAt,
 		})
-		if err := setValue(b, lessonID, *lesson); err != nil {
-			return err
-		}
-
-		lastTaskRecord.LessonAt = lesson.DateTime
-		lastTaskRecord.LessonID = lessonID
-		return setValue(b, lastTaskRecord.ID, lastTaskRecord)
+		return setValue(b, lessonID, *lesson)
 	})
 }
 
@@ -325,25 +416,34 @@ func (d *DB) UnregisterAllFromLesson(lessonID LessonID) (int, error) {
 
 		var remaining []EnrolledTask
 		for _, enrolled := range lesson.EnrolledTasks {
-			if enrolled.Status != RegisterTaskRecord {
+			if enrolled.Status != RegisterRecord {
 				remaining = append(remaining, enrolled)
 				continue
 			}
 
-			taskRecord, err := getValue[TaskRecord](b, enrolled.TaskRecordID)
+			// Read the RegisterRecord to copy content, AuthorName, and SubmitAt.
+			regRecord, err := readRecordRaw(b, enrolled.TaskRecordID)
 			if err != nil {
 				return err
 			}
-			taskRecord.Status = RevokedTaskRecord
-			if err := setValue(b, taskRecord.ID, *taskRecord); err != nil {
-				return err
+
+			revokeRecord := TaskRecord{
+				TaskID:     enrolled.TaskID,
+				StudentID:  enrolled.StudentID,
+				AuthorID:   enrolled.StudentID,
+				AuthorName: regRecord.AuthorName,
+				Type:       RevokeRecord,
+				LessonID:   lessonID,
+				CreatedAt:  time.Now(),
+				SubmitAt:   regRecord.SubmitAt,
+				Counter:    regRecord.Counter + 1,
+				Content:    regRecord.Content,
 			}
-			// Return the student to the pending queue without losing their place.
-			if err := appendPendingResubmission(b, taskRecord); err != nil {
+			if err := appendRecordInTx(b, &revokeRecord); err != nil {
 				return err
 			}
 
-			enrolled.Status = RevokedTaskRecord
+			enrolled.Status = RevokeRecord
 			lesson.PreviousEnrolledTasks = append(lesson.PreviousEnrolledTasks, enrolled)
 			count++
 		}
@@ -368,7 +468,7 @@ func (d *DB) UnregisterFromLesson(lessonID LessonID, taskID TaskID, authorID Use
 
 		existingIdx := -1
 		for i, enrolled := range lesson.EnrolledTasks {
-			if enrolled.TaskID == taskID && enrolled.AuthorID == authorID {
+			if enrolled.TaskID == taskID && enrolled.StudentID == authorID {
 				existingIdx = i
 				break
 			}
@@ -377,27 +477,35 @@ func (d *DB) UnregisterFromLesson(lessonID LessonID, taskID TaskID, authorID Use
 			return fmt.Errorf("not registered")
 		}
 
-		taskRecord, err := getValue[TaskRecord](b, lesson.EnrolledTasks[existingIdx].TaskRecordID)
-		if err != nil {
-			return err
-		}
-		if taskRecord.Status != RegisterTaskRecord {
+		enrolled := lesson.EnrolledTasks[existingIdx]
+		if enrolled.Status != RegisterRecord {
 			return fmt.Errorf("task record is not in register state")
 		}
 
-		taskRecord.Status = RevokedTaskRecord
-		if err := setValue(b, taskRecord.ID, *taskRecord); err != nil {
-			return err
-		}
-		// Re-create the submission as pending so the student can register to
-		// another lesson without resubmitting and losing their queue position.
-		if err := appendPendingResubmission(b, taskRecord); err != nil {
+		// Read the RegisterRecord to copy content, AuthorName, and SubmitAt.
+		regRecord, err := readRecordRaw(b, enrolled.TaskRecordID)
+		if err != nil {
 			return err
 		}
 
-		enrolledTask := lesson.EnrolledTasks[existingIdx]
-		enrolledTask.Status = RevokedTaskRecord
-		lesson.PreviousEnrolledTasks = append(lesson.PreviousEnrolledTasks, enrolledTask)
+		revokeRecord := TaskRecord{
+			TaskID:     taskID,
+			StudentID:  authorID,
+			AuthorID:   authorID,
+			AuthorName: regRecord.AuthorName,
+			Type:       RevokeRecord,
+			LessonID:   lessonID,
+			CreatedAt:  time.Now(),
+			SubmitAt:   regRecord.SubmitAt,
+			Counter:    regRecord.Counter + 1,
+			Content:    regRecord.Content,
+		}
+		if err := appendRecordInTx(b, &revokeRecord); err != nil {
+			return err
+		}
+
+		enrolled.Status = RevokeRecord
+		lesson.PreviousEnrolledTasks = append(lesson.PreviousEnrolledTasks, enrolled)
 		lesson.EnrolledTasks = append(lesson.EnrolledTasks[:existingIdx], lesson.EnrolledTasks[existingIdx+1:]...)
 		return setValue(b, lessonID, *lesson)
 	})

--- a/src/storage/task.go
+++ b/src/storage/task.go
@@ -15,26 +15,29 @@ import (
 type TaskID = string
 type TaskRecordID = string
 
+// TaskRecordType is the canonical type of a task record in the event log.
+type TaskRecordType string
+
 // Record type constants. These are the canonical values stored in the Type field.
 const (
-	SubmitRecord   = "submit"
-	RegisterRecord = "register"
-	RevokeRecord   = "revoke"
-	ReviewedRecord = "reviewed"
+	SubmitRecord   TaskRecordType = "submit"
+	RegisterRecord TaskRecordType = "register"
+	RevokeRecord   TaskRecordType = "revoke"
+	ReviewedRecord TaskRecordType = "reviewed"
 )
 
 type TaskRecord struct {
-	ID         string    `json:"id"`
-	TaskID     string    `json:"task_id"`
-	StudentID  string    `json:"student_id"`
-	AuthorID   string    `json:"author_id"`
-	AuthorName string    `json:"author_name"`
-	Type       string    `json:"type"`
-	Counter    int       `json:"counter"`
-	CreatedAt  time.Time `json:"created_at"`
-	SubmitAt   time.Time `json:"submit_at"`
-	Content    string    `json:"content"`
-	LessonID   string    `json:"lesson_id"`
+	ID         string         `json:"id"`
+	TaskID     string         `json:"task_id"`
+	StudentID  string         `json:"student_id"`
+	AuthorID   string         `json:"author_id"`
+	AuthorName string         `json:"author_name"`
+	Type       TaskRecordType `json:"type"`
+	Counter    int            `json:"counter"`
+	CreatedAt  time.Time      `json:"created_at"`
+	SubmitAt   time.Time      `json:"submit_at"`
+	Content    string         `json:"content"`
+	LessonID   string         `json:"lesson_id"`
 }
 
 func (r *TaskRecord) RenderAt() string {
@@ -71,7 +74,7 @@ type legacyTaskRecord struct {
 func (l *legacyTaskRecord) toTaskRecord() TaskRecord {
 	r := l.TaskRecord
 	if r.Type == "" && l.LegacyStatus != "" {
-		r.Type = l.LegacyStatus
+		r.Type = TaskRecordType(l.LegacyStatus) // legacy: convert plain string from old JSON
 	}
 	if r.AuthorID == "" && l.LegacyAuthorID != "" {
 		r.AuthorID = l.LegacyAuthorID

--- a/src/storage/task.go
+++ b/src/storage/task.go
@@ -329,6 +329,9 @@ func (d *DB) RegisterToLesson(lessonID LessonID, taskID TaskID, authorID UserID,
 		// records is oldest-first; the latest is the last element.
 		latest := records[len(records)-1]
 
+		if latest.Type == RegisterRecord {
+			return fmt.Errorf("already registered")
+		}
 		if latest.Type != SubmitRecord && latest.Type != RevokeRecord {
 			return fmt.Errorf("unexpected task state for registration on lesson: %s", latest.Type)
 		}

--- a/src/storage/task.go
+++ b/src/storage/task.go
@@ -62,6 +62,19 @@ func SortTaskRecordsNewestFirst(records []TaskRecord) {
 	})
 }
 
+// normalizeType maps legacy on-disk type strings to their canonical names.
+// Safe to call on already-canonical values.
+func normalizeType(t TaskRecordType) TaskRecordType {
+	switch t {
+	case "revoked":
+		return RevokeRecord
+	case "review":
+		return ReviewedRecord
+	default:
+		return t
+	}
+}
+
 // legacyTaskRecord is used only during unmarshalling to capture both old and
 // new field names. Call toTaskRecord() to obtain a TaskRecord.
 type legacyTaskRecord struct {
@@ -82,6 +95,7 @@ func (l *legacyTaskRecord) toTaskRecord() TaskRecord {
 	if r.AuthorName == "" && l.LegacyAuthorName != "" {
 		r.AuthorName = l.LegacyAuthorName
 	}
+	r.Type = normalizeType(r.Type)
 	return r
 }
 

--- a/src/storage/waiting_period_test.go
+++ b/src/storage/waiting_period_test.go
@@ -16,14 +16,14 @@ func TestWaitingPeriod_BlocksRegistrationAfterRecentReview(t *testing.T) {
 	assert.NoError(t, db.RegisterToLesson(lessonID, taskID, student.ID))
 
 	// Teacher reviews
-	assert.NoError(t, db.AddTaskRecord(&TaskRecord{
-		TaskID:          taskID,
-		StudentID:       student.ID,
-		EntryAuthorID:   teacher.ID,
-		EntryAuthorName: teacher.Username,
-		Content:         "needs work",
-		CreatedAt:       time.Now(),
-		Status:          ReviewTaskRecord,
+	assert.NoError(t, db.AppendTaskRecord(&TaskRecord{
+		TaskID:     taskID,
+		StudentID:  student.ID,
+		AuthorID:   teacher.ID,
+		AuthorName: teacher.Username,
+		Content:    "needs work",
+		CreatedAt:  time.Now(),
+		Type:       ReviewedRecord,
 	}))
 
 	// Student submits again
@@ -44,14 +44,14 @@ func TestWaitingPeriod_AllowsRegistrationAfterPeriodExpires(t *testing.T) {
 	assert.NoError(t, db.RegisterToLesson(lessonID, taskID, student.ID))
 
 	// Teacher reviews with a CreatedAt in the past (beyond waiting period)
-	assert.NoError(t, db.AddTaskRecord(&TaskRecord{
-		TaskID:          taskID,
-		StudentID:       student.ID,
-		EntryAuthorID:   teacher.ID,
-		EntryAuthorName: teacher.Username,
-		Content:         "needs work",
-		CreatedAt:       time.Now().Add(-25 * time.Hour),
-		Status:          ReviewTaskRecord,
+	assert.NoError(t, db.AppendTaskRecord(&TaskRecord{
+		TaskID:     taskID,
+		StudentID:  student.ID,
+		AuthorID:   teacher.ID,
+		AuthorName: teacher.Username,
+		Content:    "needs work",
+		CreatedAt:  time.Now().Add(-25 * time.Hour),
+		Type:       ReviewedRecord,
 	}))
 
 	// Student submits again
@@ -70,14 +70,14 @@ func TestWaitingPeriod_ZeroDurationSkipsCheck(t *testing.T) {
 	assert.NoError(t, db.RegisterToLesson(lessonID, taskID, student.ID))
 
 	// Teacher reviews just now
-	assert.NoError(t, db.AddTaskRecord(&TaskRecord{
-		TaskID:          taskID,
-		StudentID:       student.ID,
-		EntryAuthorID:   teacher.ID,
-		EntryAuthorName: teacher.Username,
-		Content:         "needs work",
-		CreatedAt:       time.Now(),
-		Status:          ReviewTaskRecord,
+	assert.NoError(t, db.AppendTaskRecord(&TaskRecord{
+		TaskID:     taskID,
+		StudentID:  student.ID,
+		AuthorID:   teacher.ID,
+		AuthorName: teacher.Username,
+		Content:    "needs work",
+		CreatedAt:  time.Now(),
+		Type:       ReviewedRecord,
 	}))
 
 	// Student submits again
@@ -96,14 +96,14 @@ func TestWaitingPeriod_NoWaitingPeriodParam(t *testing.T) {
 	assert.NoError(t, db.RegisterToLesson(lessonID, taskID, student.ID))
 
 	// Teacher reviews just now
-	assert.NoError(t, db.AddTaskRecord(&TaskRecord{
-		TaskID:          taskID,
-		StudentID:       student.ID,
-		EntryAuthorID:   teacher.ID,
-		EntryAuthorName: teacher.Username,
-		Content:         "needs work",
-		CreatedAt:       time.Now(),
-		Status:          ReviewTaskRecord,
+	assert.NoError(t, db.AppendTaskRecord(&TaskRecord{
+		TaskID:     taskID,
+		StudentID:  student.ID,
+		AuthorID:   teacher.ID,
+		AuthorName: teacher.Username,
+		Content:    "needs work",
+		CreatedAt:  time.Now(),
+		Type:       ReviewedRecord,
 	}))
 
 	// Student submits again

--- a/templates/partials/lesson_task_records.html
+++ b/templates/partials/lesson_task_records.html
@@ -10,28 +10,28 @@
   {{ end }}
 <li class="border rounded {{ if eq $record.StudentID $.SessionUserID }}border-blue-500{{ else }}border-gray-800{{ end }}">
   <details class="group"
-           data-status="{{$record.Status}}"
+           data-status="{{$record.Type}}"
            data-record-id="{{$record.StudentID}}:{{$record.TaskID}}">
     <summary class="cursor-pointer list-none flex flex-col sm:flex-row sm:items-center sm:justify-between px-4 py-2 rounded hover:bg-gray-800">
       <div class="flex items-center space-x-3 min-w-0">
         <span class="text-xs text-gray-400 flex-shrink-0 w-6 text-right">#{{ add $index 1 }}</span>
-        {{ if eq $record.Status "register" }}
+        {{ if eq $record.Type "register" }}
         <span class="px-2 py-0.5 rounded-full text-xs bg-yellow-700 text-yellow-200 flex-shrink-0">
           Queued
         </span>
       {{ else }}
-      <span class="px-2 py-0.5 rounded-full text-xs flex-shrink-0 {{ if eq $record.Status "revoked" }}bg-red-800 text-red-200{{ else if eq $record.Status "review" }}bg-orange-800 text-orange-200{{ else if eq $record.Status "reviewed" }}bg-green-800 text-green-200{{ else }}bg-gray-700 text-gray-300{{ end }}">
-      {{ if eq $record.Status "revoked" }}Dropped{{ else if eq $record.Status "review" }}Feedback{{ else if eq $record.Status "reviewed" }}Checked{{ else }}{{$record.Status}}{{ end }}
+      <span class="px-2 py-0.5 rounded-full text-xs flex-shrink-0 {{ if eq $record.Type "revoke" }}bg-red-800 text-red-200{{ else if eq $record.Type "reviewed" }}bg-green-800 text-green-200{{ else }}bg-gray-700 text-gray-300{{ end }}">
+      {{ if eq $record.Type "revoke" }}Dropped{{ else if eq $record.Type "reviewed" }}Checked{{ else }}{{$record.Type}}{{ end }}
       </span>
       {{ end }}
-      <span class="text-sm flex-shrink-0">@{{$record.EntryAuthorName}}</span>
+      <span class="text-sm flex-shrink-0">@{{$record.AuthorName}}</span>
       <span class="text-xs text-gray-400 truncate hidden sm:inline">{{$record.TaskTitle}}</span>
     </div>
     <div class="text-xs text-gray-400 truncate sm:hidden pl-1">
       {{$record.TaskTitle}}
     </div>
     <div class="text-xs text-gray-400 flex-shrink-0 sm:ml-4 pl-1 sm:pl-0">
-    {{ if not $record.RegisteredAt.IsZero }}{{ formatDateTime $record.RegisteredAt }}{{ else }}{{ formatDateTime $record.CreatedAt }}{{ end }}
+    {{ if not $record.SubmitAt.IsZero }}{{ formatDateTime $record.SubmitAt }}{{ else }}{{ formatDateTime $record.CreatedAt }}{{ end }}
     </div>
   </summary>
   <div class="px-4 pb-4 pt-2">
@@ -62,18 +62,16 @@
           <div class="text-xs flex items-center justify-between mb-1">
             <div class="flex items-center space-x-2">
               <span class="text-gray-600">#{{ add $i 1 }}</span>
-              <span class="{{ if ne $jr.EntryAuthorID $jr.StudentID }}journal-author-teacher{{ else }}journal-author-student{{ end }}">@{{$jr.EntryAuthorName}}</span>
+              <span class="{{ if ne $jr.AuthorID $jr.StudentID }}journal-author-teacher{{ else }}journal-author-student{{ end }}">@{{$jr.AuthorName}}</span>
               <span class="text-gray-500">{{ formatDateTime $jr.CreatedAt }}</span>
             </div>
-            {{ if eq $jr.Status "submit" }}
+            {{ if eq $jr.Type "submit" }}
             <span class="text-blue-400">Pending</span>
-            {{ else if eq $jr.Status "register" }}
+            {{ else if eq $jr.Type "register" }}
             <span class="text-yellow-400">Queued</span>
-            {{ else if eq $jr.Status "revoked" }}
+            {{ else if eq $jr.Type "revoke" }}
             <span class="text-red-400">Dropped</span>
-            {{ else if eq $jr.Status "review" }}
-            <span class="text-orange-400">Feedback</span>
-            {{ else if eq $jr.Status "reviewed" }}
+            {{ else if eq $jr.Type "reviewed" }}
             <span class="text-green-400">Checked</span>
             {{ end }}
           </div>
@@ -94,8 +92,8 @@
       {{ range $record.PreviousRecords }}
       <div class="p-3 bg-gray-900 rounded mb-1 border border-gray-700">
         <div class="flex items-center space-x-2 mb-1">
-        <span class="px-2 py-0.5 rounded-full text-xs {{ if eq .Status "reviewed" }}bg-green-800 text-green-200{{ else if eq .Status "revoked" }}bg-red-800 text-red-200{{ else }}bg-gray-700 text-gray-300{{ end }}">
-        {{ if eq .Status "reviewed" }}Checked{{ else if eq .Status "revoked" }}Dropped{{ else }}{{ .Status }}{{ end }}
+        <span class="px-2 py-0.5 rounded-full text-xs {{ if eq .Type "reviewed" }}bg-green-800 text-green-200{{ else if eq .Type "revoke" }}bg-red-800 text-red-200{{ else }}bg-gray-700 text-gray-300{{ end }}">
+        {{ if eq .Type "reviewed" }}Checked{{ else if eq .Type "revoke" }}Dropped{{ else }}{{ .Type }}{{ end }}
         </span>
         <span class="text-xs text-gray-500">{{ formatDateTime .CreatedAt }}</span>
       </div>
@@ -116,7 +114,7 @@
     <div class="text-xs text-gray-500 mt-2">
     submitted: {{ if $record.CreatedAt.IsZero }}-{{ else }}{{ formatDateTime $record.CreatedAt }}{{ end }}
       <br />
-    registered: {{ if $record.RegisteredAt.IsZero }}-{{ else }}{{ formatDateTime $record.RegisteredAt }}{{ end }}
+    registered: {{ if $record.SubmitAt.IsZero }}-{{ else }}{{ formatDateTime $record.SubmitAt }}{{ end }}
     </div>
   </div>
   {{ if $record.ReviewRecords }}
@@ -126,7 +124,7 @@
     <hr class="border-gray-700 my-2" />
     {{ end }}
     <div class="text-xs text-gray-500 mb-1">
-      // review by @{{$rev.EntryAuthorName}}
+      // review by @{{$rev.AuthorName}}
     </div>
     <div class="text-xs markdown">
       {{ markdown $rev.Content }}

--- a/templates/task.html
+++ b/templates/task.html
@@ -92,7 +92,7 @@
     {{ $.WaitingMessage }}
   </p>
   {{ end }}
-  {{ if and (eq .Type "submit") (eq .AuthorID $.SessionUserID) }}
+  {{ if and (or (eq .Type "submit") (eq .Type "revoke")) (eq .AuthorID $.SessionUserID) }}
   <form>
     <input type="hidden" name="taskRecordID" value="{{.TaskID}}" />
     <input type="hidden" name="studentID" value="{{.StudentID}}" />

--- a/templates/task.html
+++ b/templates/task.html
@@ -45,7 +45,7 @@
     <span class="flex items-center space-x-1">
       {{ if .Score }}<span class="text-green-300">{{.Score}}</span>{{ end }}
       {{ with .LatestRecord }}
-      <span class="{{ if eq .Status "reviewed" }}text-green-400{{ else if eq .Status "review" }}text-orange-400 {{ else if eq .Status "register" }}text-yellow-400 {{ else if eq .Status "revoked" }}text-red-400{{ else }}text-blue-400{{ end }}">{{ if eq .Status "reviewed" }}Checked{{ else if eq .Status "review" }}Feedback{{ else if eq .Status "register" }}Queued{{ else if eq .Status "revoked" }}Dropped{{ else }}Pending{{ end }}</span>
+      <span class="{{ if eq .Type "reviewed" }}text-green-400{{ else if eq .Type "register" }}text-yellow-400 {{ else if eq .Type "revoke" }}text-red-400{{ else }}text-blue-400{{ end }}">{{ if eq .Type "reviewed" }}Checked{{ else if eq .Type "register" }}Queued{{ else if eq .Type "revoke" }}Dropped{{ else }}Pending{{ end }}</span>
       {{ end }}
       {{ if $.JournalSummary }}<span class="text-gray-600">({{$.JournalSummary}})</span>{{ end }}
     </span>
@@ -57,19 +57,17 @@
       <div class="text-xs flex items-center justify-between mb-1">
         <div class="flex items-center space-x-2">
           <span class="text-gray-600">#{{ sub $total $i }}</span>
-          <span class="{{ if ne $record.EntryAuthorID $record.StudentID }}journal-author-teacher{{ else }}journal-author-student{{ end }}">@{{$record.EntryAuthorName}}</span>
+          <span class="{{ if ne $record.AuthorID $record.StudentID }}journal-author-teacher{{ else }}journal-author-student{{ end }}">@{{$record.AuthorName}}</span>
           <span class="text-gray-500">{{ formatDateTime $record.CreatedAt }}</span>
         </div>
-        {{ if eq $record.Status "submit" }}
+        {{ if eq $record.Type "submit" }}
         <span class="text-blue-400">Pending</span>
-        {{ else if eq $record.Status "register" }}
+        {{ else if eq $record.Type "register" }}
         <a class="text-yellow-400 hover:text-yellow-300"
            href="/lesson/{{$record.LessonID}}">Queued</a>
-        {{ else if eq $record.Status "revoked" }}
+        {{ else if eq $record.Type "revoke" }}
         <span class="text-red-400">Dropped</span>
-        {{ else if eq $record.Status "review" }}
-        <span class="text-orange-400">Feedback</span>
-        {{ else if eq $record.Status "reviewed" }}
+        {{ else if eq $record.Type "reviewed" }}
         <span class="text-green-400">Checked</span>
         {{ end }}
       </div>
@@ -94,7 +92,7 @@
     {{ $.WaitingMessage }}
   </p>
   {{ end }}
-  {{ if and (eq .Status "submit") (eq .EntryAuthorID $.SessionUserID) }}
+  {{ if and (eq .Type "submit") (eq .AuthorID $.SessionUserID) }}
   <form>
     <input type="hidden" name="taskRecordID" value="{{.TaskID}}" />
     <input type="hidden" name="studentID" value="{{.StudentID}}" />
@@ -108,7 +106,7 @@
       </p>
     </div>
   </form>
-  {{ else if eq .Status "register" }}
+  {{ else if eq .Type "register" }}
   <ul class="space-y-1">
     <li class="border-b border-gray-800 pb-1">
       <div class="text-xs flex items-center justify-between py-1 px-1">
@@ -122,7 +120,7 @@
         </a>
       {{ else }}
         <a class="text-yellow-400 hover:text-yellow-300"
-           href="/lesson/{{.LessonID}}">{{.LessonAt.Format "2006-01-02 15:04"}}</a>
+           href="/lesson/{{.LessonID}}">lesson</a>
         {{ end }}
         <form action="/api/lesson/{{.LessonID}}/unregister" method="post">
           <input type="hidden" name="taskID" value="{{.TaskID}}" />

--- a/templates/user.html
+++ b/templates/user.html
@@ -95,14 +95,14 @@
           <span class="flex-shrink-0">{{.Title}}</span>
           {{ if $journal }}
           {{ with index $journal 0 }}
-          <span class="text-gray-500 truncate">{{.EntryAuthorName}}:
-          {{ if ne .EntryAuthorID .StudentID }}{{ boldScore (getTitle .Content) }}{{ else }}{{ getTitle .Content }}{{ end }}</span>
+          <span class="text-gray-500 truncate">{{.AuthorName}}:
+          {{ if ne .AuthorID .StudentID }}{{ boldScore (getTitle .Content) }}{{ else }}{{ getTitle .Content }}{{ end }}</span>
           {{ end }}
           {{ end }}
         </span>
         {{ if $status }}
-      <span class="flex-shrink-0 ml-2 px-2 py-0.5 rounded-full text-xs {{ if eq $status "submit" }}bg-blue-800 text-blue-200 {{ else if eq $status "register" }}bg-yellow-700 text-yellow-200 {{ else if eq $status "revoked" }}bg-red-800 text-red-200 {{ else if eq $status "review" }}bg-orange-800 text-orange-200 {{ else if eq $status "reviewed" }}bg-green-800 text-green-200{{ else }}bg-gray-700 text-gray-300{{ end }}">
-      {{ if eq $status "submit" }}Pending{{ else if eq $status "register" }}Queued{{ else if eq $status "revoked" }}Dropped{{ else if eq $status "review" }}Feedback{{ else if eq $status "reviewed" }}Checked{{ else }}{{$status}}{{ end }}
+      <span class="flex-shrink-0 ml-2 px-2 py-0.5 rounded-full text-xs {{ if eq $status "submit" }}bg-blue-800 text-blue-200 {{ else if eq $status "register" }}bg-yellow-700 text-yellow-200 {{ else if eq $status "revoke" }}bg-red-800 text-red-200 {{ else if eq $status "reviewed" }}bg-green-800 text-green-200{{ else }}bg-gray-700 text-gray-300{{ end }}">
+      {{ if eq $status "submit" }}Pending{{ else if eq $status "register" }}Queued{{ else if eq $status "revoke" }}Dropped{{ else if eq $status "reviewed" }}Checked{{ else }}{{$status}}{{ end }}
       </span>
       {{ end }}
     </a>

--- a/templates/users.html
+++ b/templates/users.html
@@ -344,8 +344,8 @@
               {{ if and $td.Score (ne $td.Score "0") }}
               <span class="text-green-300">{{$td.Score}}</span>
               {{ end }}
-            <span class="{{ if eq $td.Status "reviewed" }}text-teal-400{{ else if eq $td.Status "review" }}text-orange-400{{ else if eq $td.Status "register" }}text-purple-400{{ else if eq $td.Status "revoked" }}text-red-400{{ else }}text-blue-400{{ end }}">
-            {{ if eq $td.Status "reviewed" }}Checked{{ else if eq $td.Status "review" }}Feedback{{ else if eq $td.Status "register" }}Queued{{ else if eq $td.Status "revoked" }}Dropped{{ else }}Pending{{ end }}
+            <span class="{{ if eq $td.Status "reviewed" }}text-teal-400{{ else if eq $td.Status "register" }}text-purple-400{{ else if eq $td.Status "revoke" }}text-red-400{{ else }}text-blue-400{{ end }}">
+            {{ if eq $td.Status "reviewed" }}Checked{{ else if eq $td.Status "register" }}Queued{{ else if eq $td.Status "revoke" }}Dropped{{ else }}Pending{{ end }}
             </span>
             {{ if $td.Summary }}
             <span class="text-gray-500">({{$td.Summary}})</span>

--- a/tests/lesson-cascade-delete.hurl
+++ b/tests/lesson-cascade-delete.hurl
@@ -91,13 +91,13 @@ Cookie: user_data={{student_token}}
 
 HTTP 404
 
-# Step 9: Task record reverted to submit — no longer shows Queued
+# Step 9: Task record reverted to dropped after cascade delete
 GET {{base_url}}/user/{{student_id}}/task/{{task_id}}
 Cookie: user_data={{student_token}}
 
 HTTP 200
 [Asserts]
-body not contains "Queued"
+body contains "Dropped"
 
 # Step 10: Student can register to a different lesson (task is back to submit)
 POST {{base_url}}/api/lessons

--- a/tests/ui/submit-collapses-pending.hurl
+++ b/tests/ui/submit-collapses-pending.hurl
@@ -1,8 +1,7 @@
-# Submit Collapses Pending Test
-# Verifies that the older pending record is collapsed to Dropped when a student
-# adds a new submission while an older one is pending. After the second
-# submission the task page must show a Pending record (the new one) and at least
-# one Dropped (the old one).
+# Submit Stacks in Log Test
+# Verifies that when a student adds a second submission while the first is still
+# pending (not registered), both records appear as Pending in the task journal.
+# The new event-log model does not collapse old pending submissions.
 #
 # Prerequisites: server running against a fresh DB with default config
 #   (teacher_ids: ["123"]).
@@ -34,7 +33,7 @@ content: First pending submission
 
 HTTP 303
 
-# Step 3: Student submits second version (first must get Dropped status)
+# Step 3: Student submits second version
 POST {{base_url}}/user/{{student_id}}/task/{{task_id}}/journal
 Cookie: user_data={{student_token}}
 [FormParams]
@@ -42,11 +41,11 @@ content: Second submission
 
 HTTP 303
 
-# Task page shows new submission as Pending and the old one as Dropped
+# Task page shows both submissions as Pending; no Dropped record appears
 GET {{base_url}}/user/{{student_id}}/task/{{task_id}}
 Cookie: user_data={{student_token}}
 
 HTTP 200
 [Asserts]
 body contains "Pending"
-body contains "Dropped"
+body not contains "Dropped"

--- a/tests/ui/user-list-student-row.hurl
+++ b/tests/ui/user-list-student-row.hurl
@@ -85,4 +85,4 @@ body contains "@Row Student"
 # Task status and summary counters
 body contains "/user/{{student_id}}/task/task1"
 body contains "Queued"
-body contains "(q:1)"
+body contains "q:1"


### PR DESCRIPTION
## Summary

- Replaces the mutable `TaskRecord` model (where `Status` was updated in place) with an immutable append-only event log: each student action (`submit`, `register`, `revoke`) and teacher action (`reviewed`) appends a new record rather than mutating an existing one
- Adds `(SubmitAt, Counter)` composite key per record: `SubmitAt` resets on each new student submission, `Counter` increments monotonically within a submission round — together they uniquely identify a record's position in the submission timeline
- After a revoke, students can re-register without resubmitting (the `RevokeRecord` is a valid state for `RegisterToLesson`)
- Renames fields for clarity: `EntryAuthorID` → `AuthorID`, `EntryAuthorName` → `AuthorName`, `Status` → `Type` on `TaskRecord`; renames type constants (`SubmitTaskRecord` → `SubmitRecord`, `RevokedTaskRecord` → `RevokeRecord`, etc.)
- Adds `normalizeLegacyRecords` shim so existing on-disk data (old `state`/`entry_author_id` JSON fields, old `revoked`/`review` type strings) is transparently upgraded on read — can be removed once no legacy databases exist

## Test plan

- [ ] `make test` passes (unit + storage flow tests)
- [ ] `make format-check lint` passes (0 issues)
- [ ] Manual: submit a task, register to a lesson, revoke, re-register without resubmitting
- [ ] Manual: teacher reviews a task; lesson enrollment shows "Checked"; score rules pick up the review time
- [ ] Manual: existing database with old-format records loads without errors (legacy normalization)